### PR TITLE
Update Factory.php

### DIFF
--- a/src/Common/Factory.php
+++ b/src/Common/Factory.php
@@ -235,8 +235,8 @@ abstract class Factory
         $dom->loadXML($this->xml);
         //a assinatura só faz sentido no XML, os demais formatos
         //não devem conter dados da assinatura
-        $node = Signer::removeSignature($dom);
-        $sxml = simplexml_load_string($node->saveXML());
+        $node = Signer::removeSignature($dom->saveXML());
+        $sxml = simplexml_load_string($node);
         return str_replace(
             '@attributes',
             'attributes',


### PR DESCRIPTION
Signer::removeSignature estava recebendo um objeto DOMDocument e não conseguia validar na função isXML quando o objetivo era usar o método toArray da classe. Exemplo: Event::evtInfoEmpregador($configJson, $empregador)->toArray(); Retornava: ErrorException in Validator.php line 59:
trim() expects parameter 1 to be string, object given