### PR TITLE
PHPUnit TestCase com PSR-1

### DIFF
--- a/tests/ESocialTestCase.php
+++ b/tests/ESocialTestCase.php
@@ -3,8 +3,9 @@
 namespace NFePHP\eSocial\Tests;
 
 use NFePHP\Common\Certificate;
+use PHPUnit\Framework\TestCase;
 
-class ESocialTestCase extends \PHPUnit_Framework_TestCase
+class ESocialTestCase extends TestCase
 {
     public $fixturesPath = '';
 


### PR DESCRIPTION
Usei a [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) enquanto extendendo a classe `PHPUnit TestCase`. Isso irá nos ajudar quando migrarmos para o `PHPUnit 6`, que [não mais suporta _snake case namespaces_](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).