### PR TITLE
Padronização dos constructors com certificado nulo e parametro

### DIFF
--- a/jsonSchemes/v02_04_02/evtTabAmbiente.schema
+++ b/jsonSchemes/v02_04_02/evtTabAmbiente.schema
@@ -30,7 +30,7 @@
             "pattern": "INC|ALT|EXC"
         },
         "dadosambiente": {
-            "required": true,
+            "required": false,
             "type": "object",
             "properties": {
                 "dscamb": {

--- a/jsonSchemes/v02_04_02/evtTabCargo.schema
+++ b/jsonSchemes/v02_04_02/evtTabCargo.schema
@@ -30,7 +30,7 @@
             "pattern": "INC|ALT|EXC"
         },
         "dadoscargo": {
-            "required": true,
+            "required": false,
             "type": "object",
             "properties": {
                 "nmcargo": {

--- a/jsonSchemes/v02_04_02/evtTabCarreira.schema
+++ b/jsonSchemes/v02_04_02/evtTabCarreira.schema
@@ -30,7 +30,7 @@
             "pattern": "INC|ALT|EXC"
         },
         "dadoscarreira": {
-            "required": true,
+            "required": false,
             "type": "object",
             "properties": {
                 "dsccarreira": {

--- a/jsonSchemes/v02_04_02/evtTabFuncao.schema
+++ b/jsonSchemes/v02_04_02/evtTabFuncao.schema
@@ -30,7 +30,7 @@
             "pattern": "INC|ALT|EXC"
         },
         "dadosfuncao": {
-            "required": true,
+            "required": false,
             "type": "object",
             "properties": {
                 "dscfuncao": {

--- a/jsonSchemes/v02_04_02/evtTabHorTur.schema
+++ b/jsonSchemes/v02_04_02/evtTabHorTur.schema
@@ -30,7 +30,7 @@
             "pattern": "INC|ALT|EXC"
         },
         "dadoshorcontratual": {
-            "required": true,
+            "required": false,
             "type": "object",
             "properties": {
                 "hrentr": {

--- a/jsonSchemes/v02_04_02/evtTabLotacao.schema
+++ b/jsonSchemes/v02_04_02/evtTabLotacao.schema
@@ -30,7 +30,7 @@
             "pattern": "INC|ALT|EXC"
         },
         "dadoslotacao": {
-            "required": true,
+            "required": false,
             "type": "object",
             "properties": {
                 "tplotacao": {

--- a/jsonSchemes/v02_04_02/evtTabOperPort.schema
+++ b/jsonSchemes/v02_04_02/evtTabOperPort.schema
@@ -30,7 +30,7 @@
             "pattern": "INC|ALT|EXC"
         },
         "dadosoperportuario": {
-            "required": true,
+            "required": false,
             "type": "object",
             "properties": {
                 "aliqrat" : {

--- a/src/Factories/EvtAdmissao.php
+++ b/src/Factories/EvtAdmissao.php
@@ -42,14 +42,16 @@ class EvtAdmissao extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtAfastTemp.php
+++ b/src/Factories/EvtAfastTemp.php
@@ -48,14 +48,16 @@ class EvtAfastTemp extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtAltCadastral.php
+++ b/src/Factories/EvtAltCadastral.php
@@ -48,14 +48,16 @@ class EvtAltCadastral extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtAltContratual.php
+++ b/src/Factories/EvtAltContratual.php
@@ -48,14 +48,16 @@ class EvtAltContratual extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtAqProd.php
+++ b/src/Factories/EvtAqProd.php
@@ -51,14 +51,16 @@ class EvtAqProd extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtAvPrevio.php
+++ b/src/Factories/EvtAvPrevio.php
@@ -48,14 +48,16 @@ class EvtAvPrevio extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtBasesTrab.php
+++ b/src/Factories/EvtBasesTrab.php
@@ -47,14 +47,16 @@ class EvtBasesTrab extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtBenPrRP.php
+++ b/src/Factories/EvtBenPrRP.php
@@ -42,19 +42,22 @@ class EvtBenPrRP extends Factory implements FactoryInterface
      * @var array
      */
     protected $parameters = [];
+
     /**
      * Constructor
      *
      * @param string $config
      * @param stdClass $std
      * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate = null
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtCAT.php
+++ b/src/Factories/EvtCAT.php
@@ -44,14 +44,16 @@ class EvtCAT extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtCS.php
+++ b/src/Factories/EvtCS.php
@@ -48,14 +48,16 @@ class EvtCS extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtCdBenPrRP.php
+++ b/src/Factories/EvtCdBenPrRP.php
@@ -49,13 +49,15 @@ class EvtCdBenPrRP extends Factory implements FactoryInterface
      * @param string $config
      * @param stdClass $std
      * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate = null
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtComProd.php
+++ b/src/Factories/EvtComProd.php
@@ -48,14 +48,16 @@ class EvtComProd extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtContrSindPatr.php
+++ b/src/Factories/EvtContrSindPatr.php
@@ -48,14 +48,16 @@ class EvtContrSindPatr extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtContratAvNP.php
+++ b/src/Factories/EvtContratAvNP.php
@@ -48,14 +48,16 @@ class EvtContratAvNP extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtDeslig.php
+++ b/src/Factories/EvtDeslig.php
@@ -45,16 +45,19 @@ class EvtDeslig extends Factory implements FactoryInterface
 
     /**
      * Constructor
+     *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtExclusao.php
+++ b/src/Factories/EvtExclusao.php
@@ -48,14 +48,16 @@ class EvtExclusao extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtExpRisco.php
+++ b/src/Factories/EvtExpRisco.php
@@ -40,16 +40,19 @@ class EvtExpRisco extends Factory implements FactoryInterface
 
     /**
      * Constructor
+     *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtFechaEvPer.php
+++ b/src/Factories/EvtFechaEvPer.php
@@ -48,14 +48,16 @@ class EvtFechaEvPer extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtInfoComplPer.php
+++ b/src/Factories/EvtInfoComplPer.php
@@ -48,14 +48,16 @@ class EvtInfoComplPer extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtInfoEmpregador.php
+++ b/src/Factories/EvtInfoEmpregador.php
@@ -34,16 +34,19 @@ class EvtInfoEmpregador extends Factory implements FactoryInterface
 
     /**
      * Constructor
+     *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate = null
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtInsApo.php
+++ b/src/Factories/EvtInsApo.php
@@ -48,14 +48,16 @@ class EvtInsApo extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtIrrf.php
+++ b/src/Factories/EvtIrrf.php
@@ -47,14 +47,16 @@ class EvtIrrf extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtIrrfBenef.php
+++ b/src/Factories/EvtIrrfBenef.php
@@ -47,14 +47,16 @@ class EvtIrrfBenef extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtMonit.php
+++ b/src/Factories/EvtMonit.php
@@ -39,16 +39,19 @@ class EvtMonit extends Factory implements FactoryInterface
 
     /**
      * Constructor
+     *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtPgtos.php
+++ b/src/Factories/EvtPgtos.php
@@ -46,14 +46,16 @@ class EvtPgtos extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtReabreEvPer.php
+++ b/src/Factories/EvtReabreEvPer.php
@@ -48,14 +48,16 @@ class EvtReabreEvPer extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtReintegr.php
+++ b/src/Factories/EvtReintegr.php
@@ -47,14 +47,16 @@ class EvtReintegr extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtRemun.php
+++ b/src/Factories/EvtRemun.php
@@ -48,14 +48,16 @@ class EvtRemun extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtRmnRPPS.php
+++ b/src/Factories/EvtRmnRPPS.php
@@ -209,7 +209,7 @@ class EvtRmnRPPS extends Factory implements FactoryInterface
     {
         if (!isset($std->infoperapur)) {
             return;
-        }    
+        }
         $infoPerApur = $this->dom->createElement("infoPerApur");
         $this->ideestab($infoPerApur, $std);
         $node->appendChild($infoPerApur);
@@ -403,7 +403,7 @@ class EvtRmnRPPS extends Factory implements FactoryInterface
     {
         if (!isset($std->infoperant)) {
             return;
-        }    
+        }
         $infoPerAnt = $this->dom->createElement("infoPerAnt");
         //add ideadc to infoPerAnt
         $this->ideadc($infoPerAnt, $std);
@@ -420,13 +420,22 @@ class EvtRmnRPPS extends Factory implements FactoryInterface
         foreach ($std->infoperant->ideadc as $adc) {
             $ideADC = $this->dom->createElement("ideADC");
             $this->dom->addChild(
-                    $ideADC, "dtLei", $adc->dtlei, true
+                $ideADC,
+                "dtLei",
+                $adc->dtlei,
+                true
             );
             $this->dom->addChild(
-                    $ideADC, "nrLei", $adc->nrlei, true
+                $ideADC,
+                "nrLei",
+                $adc->nrlei,
+                true
             );
             $this->dom->addChild(
-                    $ideADC, "dtEf", !empty($adc->dtef) ? $adc->dtef : null, false
+                $ideADC,
+                "dtEf",
+                !empty($adc->dtef) ? $adc->dtef : null,
+                false
             );
             //add ideperiodo to ideADC
             $this->ideperiodo($ideADC, $adc);
@@ -520,8 +529,8 @@ class EvtRmnRPPS extends Factory implements FactoryInterface
                     $ideEstab->appendChild($remunPerAnt);
                 }
                 $idePeriodo->appendChild($ideEstab);
-            }    
+            }
             $node->appendChild($idePeriodo);
-        }    
+        }
     }
 }

--- a/src/Factories/EvtRmnRPPS.php
+++ b/src/Factories/EvtRmnRPPS.php
@@ -51,11 +51,16 @@ class EvtRmnRPPS extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
-    public function __construct($config, stdClass $std, Certificate $certificate)
-    {
-        parent::__construct($config, $std, $certificate);
+    public function __construct(
+        $config,
+        stdClass $std,
+        Certificate $certificate = null,
+        $date = ''
+    ) {
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtTSVAltContr.php
+++ b/src/Factories/EvtTSVAltContr.php
@@ -48,14 +48,16 @@ class EvtTSVAltContr extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtTSVInicio.php
+++ b/src/Factories/EvtTSVInicio.php
@@ -48,14 +48,16 @@ class EvtTSVInicio extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtTSVTermino.php
+++ b/src/Factories/EvtTSVTermino.php
@@ -48,14 +48,16 @@ class EvtTSVTermino extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtTabAmbiente.php
+++ b/src/Factories/EvtTabAmbiente.php
@@ -39,16 +39,19 @@ class EvtTabAmbiente extends Factory implements FactoryInterface
 
     /**
      * Constructor
+     *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtTabCargo.php
+++ b/src/Factories/EvtTabCargo.php
@@ -51,14 +51,16 @@ class EvtTabCargo extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtTabCarreira.php
+++ b/src/Factories/EvtTabCarreira.php
@@ -38,16 +38,19 @@ class EvtTabCarreira extends Factory implements FactoryInterface
 
     /**
      * Constructor
+     *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtTabEquipamento.php
+++ b/src/Factories/EvtTabEquipamento.php
@@ -39,16 +39,19 @@ class EvtTabEquipamento extends Factory implements FactoryInterface
 
     /**
      * Constructor
+     *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtTabEstab.php
+++ b/src/Factories/EvtTabEstab.php
@@ -50,14 +50,16 @@ class EvtTabEstab extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtTabFuncao.php
+++ b/src/Factories/EvtTabFuncao.php
@@ -51,14 +51,16 @@ class EvtTabFuncao extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtTabHorTur.php
+++ b/src/Factories/EvtTabHorTur.php
@@ -41,16 +41,19 @@ class EvtTabHorTur extends Factory implements FactoryInterface
 
     /**
      * Constructor
+     *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtTabLotacao.php
+++ b/src/Factories/EvtTabLotacao.php
@@ -51,14 +51,16 @@ class EvtTabLotacao extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtTabOperPort.php
+++ b/src/Factories/EvtTabOperPort.php
@@ -44,16 +44,19 @@ class EvtTabOperPort extends Factory implements FactoryInterface
     
     /**
      * Constructor
+     *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtTabProcesso.php
+++ b/src/Factories/EvtTabProcesso.php
@@ -50,14 +50,16 @@ class EvtTabProcesso extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtTabProcesso.php
+++ b/src/Factories/EvtTabProcesso.php
@@ -130,80 +130,83 @@ class EvtTabProcesso extends Factory implements FactoryInterface
         }
         $node->appendChild($ide);
 
-        $dados = $this->dom->createElement("dadosProc");
-        $this->dom->addChild(
-            $dados,
-            "indAutoria",
-            ! empty($this->std->dadosproc->indautoria)
-                ? $this->std->dadosproc->indautoria
-                : null,
-            false
-        );
-        $this->dom->addChild(
-            $dados,
-            "indMatProc",
-            $this->std->dadosproc->indmatproc,
-            true
-        );
-        $this->dom->addChild(
-            $dados,
-            "observacao",
-            !empty($this->std->dadosproc->observacao) ? $this->std->dadosproc->observacao : null,
-            false
-        );
-        if (! empty($this->std->dadosproc->dadosprocjud)) {
-            $dadosProcJud = $this->dom->createElement("dadosProcJud");
+        if (!empty($this->std->dadosproc)) {
+            $dados = $this->dom->createElement("dadosProc");
             $this->dom->addChild(
-                $dadosProcJud,
-                "ufVara",
-                $this->std->dadosproc->dadosprocjud->ufvara,
+                $dados,
+                "indAutoria",
+                ! empty($this->std->dadosproc->indautoria)
+                    ? $this->std->dadosproc->indautoria
+                    : null,
+                false
+            );
+
+            $this->dom->addChild(
+                $dados,
+                "indMatProc",
+                $this->std->dadosproc->indmatproc,
                 true
             );
             $this->dom->addChild(
-                $dadosProcJud,
-                "codMunic",
-                $this->std->dadosproc->dadosprocjud->codmunic,
-                true
+                $dados,
+                "observacao",
+                !empty($this->std->dadosproc->observacao) ? $this->std->dadosproc->observacao : null,
+                false
             );
-            $this->dom->addChild(
-                $dadosProcJud,
-                "idVara",
-                $this->std->dadosproc->dadosprocjud->idvara,
-                true
-            );
-            $dados->appendChild($dadosProcJud);
-        }
-        if (! empty($this->std->dadosproc->infosusp)) {
-            foreach ($this->std->dadosproc->infosusp as $susp) {
-                $infoSusp = $this->dom->createElement("infoSusp");
+            if (! empty($this->std->dadosproc->dadosprocjud)) {
+                $dadosProcJud = $this->dom->createElement("dadosProcJud");
                 $this->dom->addChild(
-                    $infoSusp,
-                    "codSusp",
-                    $susp->codsusp,
+                    $dadosProcJud,
+                    "ufVara",
+                    $this->std->dadosproc->dadosprocjud->ufvara,
                     true
                 );
                 $this->dom->addChild(
-                    $infoSusp,
-                    "indSusp",
-                    $susp->indsusp,
+                    $dadosProcJud,
+                    "codMunic",
+                    $this->std->dadosproc->dadosprocjud->codmunic,
                     true
                 );
                 $this->dom->addChild(
-                    $infoSusp,
-                    "dtDecisao",
-                    $susp->dtdecisao,
+                    $dadosProcJud,
+                    "idVara",
+                    $this->std->dadosproc->dadosprocjud->idvara,
                     true
                 );
-                $this->dom->addChild(
-                    $infoSusp,
-                    "indDeposito",
-                    $susp->inddeposito,
-                    true
-                );
-                $dados->appendChild($infoSusp);
+                $dados->appendChild($dadosProcJud);
             }
+            if (! empty($this->std->dadosproc->infosusp)) {
+                foreach ($this->std->dadosproc->infosusp as $susp) {
+                    $infoSusp = $this->dom->createElement("infoSusp");
+                    $this->dom->addChild(
+                        $infoSusp,
+                        "codSusp",
+                        $susp->codsusp,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $infoSusp,
+                        "indSusp",
+                        $susp->indsusp,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $infoSusp,
+                        "dtDecisao",
+                        $susp->dtdecisao,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $infoSusp,
+                        "indDeposito",
+                        $susp->inddeposito,
+                        true
+                    );
+                    $dados->appendChild($infoSusp);
+                }
+            }
+            $node->appendChild($dados);
         }
-        $node->appendChild($dados);
 
         if (! empty($this->std->novavalidade) && $this->std->modo == 'ALT') {
             $newVal       = $this->std->novavalidade;

--- a/src/Factories/EvtTabRubrica.php
+++ b/src/Factories/EvtTabRubrica.php
@@ -47,14 +47,16 @@ class EvtTabRubrica extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**

--- a/src/Factories/EvtTotConting.php
+++ b/src/Factories/EvtTotConting.php
@@ -48,14 +48,16 @@ class EvtTotConting extends Factory implements FactoryInterface
      *
      * @param string $config
      * @param stdClass $std
-     * @param Certificate $certificate
+     * @param Certificate $certificate | null
+     * @param string $date
      */
     public function __construct(
         $config,
         stdClass $std,
-        Certificate $certificate
+        Certificate $certificate = null,
+        $date = ''
     ) {
-        parent::__construct($config, $std, $certificate);
+        parent::__construct($config, $std, $certificate, $date);
     }
 
     /**


### PR DESCRIPTION
Permitindo criar os eventos sem o certificado (para os casos em que é necessário apenas gerar o xml para outra empresa) e incluindo parâmetro de data em todos.