### PR TITLE
tag <v1:consultaEventosTabela> corrigida para <v1:consultaEventosTrabalhador>

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -372,9 +372,9 @@ class Tools extends ToolsBase
         );
         
         $body = "<v1:{$this->method}>"
-            ."<v1:consultaEventosTabela>"
+            ."<v1:consultaEventosTrabalhador>"
             .$request
-            ."</v1:consultaEventosTabela>"
+            ."</v1:consultaEventosTrabalhador>"
             ."</v1:{$this->method}>";
             
         $this->lastRequest  = $body;


### PR DESCRIPTION
tag <v1:consultaEventosTabela> corrigida para <v1:consultaEventosTrabalhador> em public function consultarEventosTrabalhador($cpfTrab, $dtIni, $dtFim)