### PR TITLE
Ordena argumentos de acordo com o SoapInterface / Atualiza versão do SOAP

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -543,12 +543,18 @@ class Tools extends ToolsBase
             "SOAPAction: \"$this->action\"",
             "Content-length: $msgSize",
         ];
+
+        // Versão do SOAP esperada é a 1.1, conforme manual do desenvolvedor eSocial versão 1.1:
+        // "Alteração da versão do SOAP de 1.2 para 1.1."
+        // http://portal.esocial.gov.br/institucional/manuais/manualorientacaodesenvolvedoresocialv1-7.pdf
         return (string) $this->soap->send(
-            $this->method,
             $this->uri,
+            $this->method,
             $this->action,
-            $envelope,
-            $parameters
+            SOAP_1_1,
+            $parameters,
+            [],
+            $envelope
         );
     }
 


### PR DESCRIPTION
- O método  $this->soap->send() estava chamando argumentos na ordem errada em relação ao esperado pelo SoapInterface e suas implementações
- Segundo a documentação do eSocial, a versão do SOAP aceita é a 1.1
- "Alteração da versão do SOAP de 1.2 para 1.1."
- Ver http://portal.esocial.gov.br/institucional/manuais/manualorientacaodesenvolvedoresocialv1-7.pdf