### PR TITLE
S-1005 infoapr não é mais obrigatorio

### DIFF
--- a/examples/schemes/v02_05_00/s1005_JsonSchemaEvtTabEstab.php
+++ b/examples/schemes/v02_05_00/s1005_JsonSchemaEvtTabEstab.php
@@ -165,8 +165,8 @@ $jsonSchema = '{
                             "maximum": 6
                         },
                         "infoapr": {
-                            "required": true,
-                            "type": "object",
+                            "required": false,
+                            "type": ["object", "null"],
                             "properties": {
                                 "contapr": {
                                     "required": true,

--- a/jsonSchemes/v02_05_00/evtTabEstab.schema
+++ b/jsonSchemes/v02_05_00/evtTabEstab.schema
@@ -147,7 +147,7 @@
                             "maximum": 6
                         },
                         "infoapr": {
-                            "required": true,
+                            "required": false,
                             "type": "object",
                             "properties": {
                                 "contapr": {

--- a/jsonSchemes/v02_05_00/evtTabEstab.schema
+++ b/jsonSchemes/v02_05_00/evtTabEstab.schema
@@ -148,7 +148,7 @@
                         },
                         "infoapr": {
                             "required": false,
-                            "type": "object",
+                            "type": ["object", "null"],
                             "properties": {
                                 "contapr": {
                                     "required": true,

--- a/schemes/v02_05_00/evtTabEstab.xsd
+++ b/schemes/v02_05_00/evtTabEstab.xsd
@@ -384,10 +384,10 @@
           </xs:sequence>
         </xs:complexType>
       </xs:element>
-      <xs:element name="infoTrab">
+      <xs:element name="infoTrab" minOccurs="0">
         <xs:complexType>
           <xs:sequence>
-            <xs:element name="regPt">
+            <xs:element name="regPt" minOccurs="0">
               <xs:simpleType>
                 <xs:annotation>
                   <xs:documentation>Registro de ponto</xs:documentation>
@@ -397,7 +397,7 @@
                 </xs:restriction>
               </xs:simpleType>
             </xs:element>
-            <xs:element name="infoApr">
+            <xs:element name="infoApr" minOccurs="0">
               <xs:annotation>
                 <xs:documentation>Informações relacionadas à contratação de aprendiz</xs:documentation>
               </xs:annotation>

--- a/src/Factories/EvtTabEstab.php
+++ b/src/Factories/EvtTabEstab.php
@@ -234,7 +234,7 @@ class EvtTabEstab extends Factory implements FactoryInterface
                 );
                 $dadosEstab->appendChild($infoObra);
             }
-
+            
             $infoTrab = $this->dom->createElement("infoTrab");
             $this->dom->addChild(
                 $infoTrab,
@@ -242,45 +242,46 @@ class EvtTabEstab extends Factory implements FactoryInterface
                 $this->std->dadosestab->infotrab->regpt,
                 true
             );
+            if (! empty($this->std->dadosestab->infoapr)) {
+                $infoApr = $this->dom->createElement("infoApr");
+                $this->dom->addChild(
+                    $infoApr,
+                    "contApr",
+                    $this->std->dadosestab->infotrab->infoapr->contapr,
+                    true
+                );
+                $this->dom->addChild(
+                    $infoApr,
+                    "nrProcJud",
+                    ! empty($this->std->dadosestab->infotrab->infoapr->nrprocjud)
+                        ? $this->std->dadosestab->infotrab->infoapr->nrprocjud
+                        : null,
+                    false
+                );
+                $this->dom->addChild(
+                    $infoApr,
+                    "contEntEd",
+                    ! empty($this->std->dadosestab->infotrab->infoapr->contented)
+                        ? $this->std->dadosestab->infotrab->infoapr->contented
+                        : null,
+                    false
+                );
 
-            $infoApr = $this->dom->createElement("infoApr");
-            $this->dom->addChild(
-                $infoApr,
-                "contApr",
-                $this->std->dadosestab->infotrab->infoapr->contapr,
-                true
-            );
-            $this->dom->addChild(
-                $infoApr,
-                "nrProcJud",
-                ! empty($this->std->dadosestab->infotrab->infoapr->nrprocjud)
-                    ? $this->std->dadosestab->infotrab->infoapr->nrprocjud
-                    : null,
-                false
-            );
-            $this->dom->addChild(
-                $infoApr,
-                "contEntEd",
-                ! empty($this->std->dadosestab->infotrab->infoapr->contented)
-                    ? $this->std->dadosestab->infotrab->infoapr->contented
-                    : null,
-                false
-            );
-
-            if (! empty($this->std->dadosestab->infotrab->infoapr->infoenteduc)) {
-                foreach ($this->std->dadosestab->infotrab->infoapr->infoenteduc as $edu) {
-                    $infoEntEduc = $this->dom->createElement("infoEntEduc");
-                    $this->dom->addChild(
-                        $infoEntEduc,
-                        "nrInsc",
-                        $edu->nrinsc,
-                        true
-                    );
-                    $infoApr->appendChild($infoEntEduc);
+                if (! empty($this->std->dadosestab->infotrab->infoapr->infoenteduc)) {
+                    foreach ($this->std->dadosestab->infotrab->infoapr->infoenteduc as $edu) {
+                        $infoEntEduc = $this->dom->createElement("infoEntEduc");
+                        $this->dom->addChild(
+                            $infoEntEduc,
+                            "nrInsc",
+                            $edu->nrinsc,
+                            true
+                        );
+                        $infoApr->appendChild($infoEntEduc);
+                    }
                 }
-            }
 
-            $infoTrab->appendChild($infoApr);
+                $infoTrab->appendChild($infoApr);
+            }
             if (! empty($this->std->dadosestab->infotrab->infopdc)) {
                 $infoPCD = $this->dom->createElement("infoPCD");
                 $this->dom->addChild(


### PR DESCRIPTION
Campo contendo informação de menores aprendizes não é mais obrigatório para o evento S-1005, os xmls enviados com o campo e que não possuem nenhum menor aprendiz estão sendo rejeitados.