### PR TITLE
Update TraitS1010.php

### DIFF
--- a/src/Factories/Traits/TraitS1010.php
+++ b/src/Factories/Traits/TraitS1010.php
@@ -332,6 +332,14 @@ trait TraitS1010
             );
             $this->dom->addChild(
                 $dadosRubrica,
+                "tetoRemun",
+                ! empty($this->std->dadosrubrica->tetoremun)
+                    ? $this->std->dadosrubrica->tetoremun
+                    : Null,
+                false
+            );
+            $this->dom->addChild(
+                $dadosRubrica,
                 "observacao",
                 ! empty($this->std->dadosrubrica->observacao)
                     ? $this->std->dadosrubrica->observacao


### PR DESCRIPTION
Estou enviando algumas Rúbricas S-1010  pra o ambiente de teste usando S-1.0 e notei que nenhuma delas estava sendo aprovada. Sempre retornava o seguinte erro " 1 - Campo de preenchimento obrigatório: Teto remuneratório específico (art. 37, XI, da CF/1988)."  Adicionei o pequeno trecho de código para que o teto remuneratório da Rubrica fosse dentro do arquivo.  No Layout existe a seguinte validação para o tetoRemun  "Preenchimento obrigatório se a natureza jurídica do declarante for Administração Pública (grupo [1])." .