### PR TITLE
Implementando evento S-1260 no layout S-1.0

### DIFF
--- a/examples/Fake/v_S_01_00_00/Fake_s1260_EvtComProd.php
+++ b/examples/Fake/v_S_01_00_00/Fake_s1260_EvtComProd.php
@@ -32,7 +32,6 @@ $std = new \stdClass();
 $std->sequencial = 1;
 $std->indretif = 1;
 $std->nrrecibo = '123456';
-$std->indapuracao = 1;
 $std->perapur = '2017-08';
 
 $std->estabelecimento = new \stdClass();

--- a/examples/schemes/v_S_01_00_00/s1260_JsonSchemaEvtComProd.php
+++ b/examples/schemes/v_S_01_00_00/s1260_JsonSchemaEvtComProd.php
@@ -35,12 +35,6 @@ $jsonSchema = '{
             "minimum": 1,
             "maximum": 2
         },
-        "indapuracao": {
-            "required": true,
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 2
-        },
         "perapur": {
             "required": true,
             "type": "string",
@@ -66,7 +60,7 @@ $jsonSchema = '{
                             "indcomerc": {
                                 "required": true,
                                 "type": "string",
-                                "pattern": "^(2|3|8|9)$"
+                                "pattern": "^(2|3|7|8|9)$"
                             },
                             "vrtotcom": {
                                 "required": true,
@@ -187,7 +181,6 @@ $std = new \stdClass();
 $std->sequencial = 1;
 $std->indretif = 1;
 $std->nrrecibo = '123456';
-$std->indapuracao = 1;
 $std->perapur = '2017-08';
 
 $std->estabelecimento = new \stdClass();

--- a/jsonSchemes/v_S_01_00_00/evtComProd.schema
+++ b/jsonSchemes/v_S_01_00_00/evtComProd.schema
@@ -14,12 +14,6 @@
             "minimum": 1,
             "maximum": 2
         },
-        "indapuracao": {
-            "required": true,
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 2
-        },
         "perapur": {
             "required": true,
             "type": "string",
@@ -45,7 +39,7 @@
                             "indcomerc": {
                                 "required": true,
                                 "type": "string",
-                                "pattern": "^(2|3|8|9)$"
+                                "pattern": "^(2|3|7|8|9)$"
                             },
                             "vrtotcom": {
                                 "required": true,

--- a/schemes/v_S_01_00_00/evtComProd.xsd
+++ b/schemes/v_S_01_00_00/evtComProd.xsd
@@ -59,7 +59,7 @@
                                                         <xs:simpleType>
                                                             <xs:annotation>
                                                                 <xs:documentation>Preencher com o número de inscrição no CAEPF do estabelecimento rural.</xs:documentation>
-                                                                <xs:documentation>Validação: Deve ser um número de inscrição válido e existente na Tabela de Estabelecimentos (S-1005). Se {indGuia}(1260_ideEvento_indGuia) estiver preenchido, o número de inscrição deve possuir {tpCaepf}(1005_infoEstab_inclusao_dadosEstab_infoCaepf_tpCaepf) em S-1005 = [3].</xs:documentation>
+                                                                <xs:documentation>Validação: Deve ser um número de inscrição válido e existente na Tabela de Estabelecimentos (S-1005).</xs:documentation>
                                                             </xs:annotation>
                                                             <xs:restriction base="xs:string">
                                                                 <xs:pattern value="\d{14}" />

--- a/src/Factories/Traits/TraitS1260.php
+++ b/src/Factories/Traits/TraitS1260.php
@@ -209,6 +209,198 @@ trait TraitS1260
      */
     protected function toNodeS100()
     {
-        throw new \Exception("TODO !!");
+        $ideEmpregador = $this->node->getElementsByTagName('ideEmpregador')->item(0);
+        //o idEvento pode variar de evento para evento
+        //então cada factory individualmente terá de construir o seu
+        $ideEvento = $this->dom->createElement("ideEvento");
+        $this->dom->addChild(
+            $ideEvento,
+            "indRetif",
+            $this->std->indretif,
+            true
+        );
+        if( $this->std->indretif == 2 ){
+			$this->dom->addChild(
+				$ideEvento,
+				"nrRecibo",
+				$this->std->nrrecibo,
+				true
+			);
+		}
+        $this->dom->addChild(
+            $ideEvento,
+            "perApur",
+            $this->std->perapur,
+            true
+        );
+        $this->dom->addChild(
+            $ideEvento,
+            "indGuia",
+            $this->std->indguia,
+            true
+        );
+        $this->dom->addChild(
+            $ideEvento,
+            "tpAmb",
+            $this->tpAmb,
+            true
+        );
+        $this->dom->addChild(
+            $ideEvento,
+            "procEmi",
+            $this->procEmi,
+            true
+        );
+        $this->dom->addChild(
+            $ideEvento,
+            "verProc",
+            $this->verProc,
+            true
+        );
+        $this->node->insertBefore($ideEvento, $ideEmpregador);
+        $infoComProd = $this->dom->createElement("infoComProd");
+        $ideEstabel = $this->dom->createElement("ideEstabel");
+        $this->dom->addChild(
+            $ideEstabel,
+            "nrInscEstabRural",
+            $this->std->estabelecimento->nrinscestabrural,
+            true
+        );
+        foreach ($this->std->estabelecimento->tpcomerc as $tpcom) {
+            $tpComerc = $this->dom->createElement("tpComerc");
+            $this->dom->addChild(
+                $tpComerc,
+                "indComerc",
+                $tpcom->indcomerc,
+                true
+            );
+            $this->dom->addChild(
+                $tpComerc,
+                "vrTotCom",
+                $tpcom->vrtotcom,
+                true
+            );
+            if (isset($tpcom->ideadquir)) {
+                foreach ($tpcom->ideadquir as $adquir) {
+                    $ideAdquir = $this->dom->createElement("ideAdquir");
+                    $this->dom->addChild(
+                        $ideAdquir,
+                        "tpInsc",
+                        $adquir->tpinsc,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $ideAdquir,
+                        "nrInsc",
+                        $adquir->nrinsc,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $ideAdquir,
+                        "vrComerc",
+                        $adquir->vrcomerc,
+                        true
+                    );
+                    if (isset($adquir->nfs)) {
+                        foreach ($adquir->nfs as $nf) {
+                            $nfs = $this->dom->createElement("nfs");
+                            $this->dom->addChild(
+                                $nfs,
+                                "serie",
+                                !empty($nf->serie) ? $nf->serie : null,
+                                false
+                            );
+                            $this->dom->addChild(
+                                $nfs,
+                                "nrDocto",
+                                $nf->nrdocto,
+                                true
+                            );
+                            $this->dom->addChild(
+                                $nfs,
+                                "dtEmisNF",
+                                $nf->dtemisnf,
+                                true
+                            );
+                            $this->dom->addChild(
+                                $nfs,
+                                "vlrBruto",
+                                $nf->vlrbruto,
+                                true
+                            );
+                            $this->dom->addChild(
+                                $nfs,
+                                "vrCPDescPR",
+                                $nf->vrcpdescpr,
+                                true
+                            );
+                            $this->dom->addChild(
+                                $nfs,
+                                "vrRatDescPR",
+                                $nf->vrratdescpr,
+                                true
+                            );
+                            $this->dom->addChild(
+                                $nfs,
+                                "vrSenarDesc",
+                                $nf->vrsenardesc,
+                                true
+                            );
+                            $ideAdquir->appendChild($nfs);
+                        }
+                    }
+                    $tpComerc->appendChild($ideAdquir);
+                }
+            }
+
+            if (isset($tpcom->infoprocjud)) {
+                foreach ($tpcom->infoprocjud as $procjud) {
+                    $infoProcJud = $this->dom->createElement("infoProcJud");
+                    $this->dom->addChild(
+                        $infoProcJud,
+                        "tpProc",
+                        $procjud->tpproc,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $infoProcJud,
+                        "nrProc",
+                        $procjud->nrproc,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $infoProcJud,
+                        "codSusp",
+                        $procjud->codsusp,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $infoProcJud,
+                        "vrCPSusp",
+                        !empty($procjud->vrcpsusp) ? $procjud->vrcpsusp : null,
+                        false
+                    );
+                    $this->dom->addChild(
+                        $infoProcJud,
+                        "vrRatSusp",
+                        !empty($procjud->vrratsusp) ? $procjud->vrratsusp : null,
+                        false
+                    );
+                    $this->dom->addChild(
+                        $infoProcJud,
+                        "vrSenarSusp",
+                        !empty($procjud->vrsenarsusp) ? $procjud->vrsenarsusp : null,
+                        false
+                    );
+                    $tpComerc->appendChild($infoProcJud);
+                }
+            }
+            $ideEstabel->appendChild($tpComerc);
+        }
+        $infoComProd->appendChild($ideEstabel);
+        $this->node->appendChild($infoComProd);
+        $this->eSocial->appendChild($this->node);
+        //$this->xml = $this->dom->saveXML($this->eSocial);
+        $this->sign();
     }
 }


### PR DESCRIPTION
Olá pessoal!

Esse evento é usado por produtores rurais e segurados especiais para informar a comercialização de seus produtos.
Se esqueci algum detalhe que impede o merge, favor avisar.

Segundo o manual de leiaute "Versão S-1.0 (consolidada até NT nº 03/2021)":

- campo "indapuracao" não existe nesse evento
- campo "indcomerc" tem nova opção: 7 - "Comercialização da produção isenta de acordo com a - Lei 13.606/2018"
