### PR TITLE
Adicionando novos campos no evento S-1299

### DIFF
--- a/examples/Fake/v02_05_00/Fake_s1299_EvtFechaEvPer.php
+++ b/examples/Fake/v02_05_00/Fake_s1299_EvtFechaEvPer.php
@@ -48,6 +48,7 @@ $std->infofech->evtcomprod = 'N';
 $std->infofech->evtcontratavnp = 'N';
 $std->infofech->evtinfocomplper = 'N';
 $std->infofech->compsemmovto = '2019-12';
+$std->infofech->indexcapur1250 = 'S';
 
 try {
     //carrega a classe responsavel por lidar com os certificados

--- a/examples/Fake/v_S_01_00_00/Fake_s1299_EvtFechaEvPer.php
+++ b/examples/Fake/v_S_01_00_00/Fake_s1299_EvtFechaEvPer.php
@@ -70,6 +70,11 @@ $std->infofech->indexcapur1250 = 'S'; //opcional mas aceita somente NULL ou S
 //Não informar se perApur >= [2021-05] ou se indApuracao = [2]. Preenchimento obrigatório caso o
 //campo tenha sido informado em fechamento anterior do mesmo período de apuração
 
+$std->infofech->transdctfweb = 'S'; //opcional
+// Solicitação de transmissão imediata da DCTFWeb.
+// Não informar se perApur < [2021-10]. Preenchimento obrigatório se perApur >= [2021-10] e
+// (classTrib em S-1000 = [04] ou indGuia estiver informado).
+
 try {
     //carrega a classe responsavel por lidar com os certificados
     $content = file_get_contents('expired_certificate.pfx');

--- a/examples/schemes/v02_05_00/s1299_JsonSchemaEvtFechaEvPer.php
+++ b/examples/schemes/v02_05_00/s1299_JsonSchemaEvtFechaEvPer.php
@@ -102,6 +102,11 @@ $jsonSchema = '{
                     "required": false,
                     "type": ["string","null"],
                     "pattern": "^(19[0-9][0-9]|2[0-9][0-9][0-9])[-/](0?[1-9]|1[0-2])$"
+                },
+                "indexcapur1250": {
+                    "required": false,
+                    "type": ["string","null"],
+                    "pattern": "^(S)$"
                 }
             }
         }
@@ -127,7 +132,7 @@ $std->infofech->evtcomprod = 'N';
 $std->infofech->evtcontratavnp = 'N';
 $std->infofech->evtinfocomplper = 'N';
 $std->infofech->compsemmovto = '2019-12';
-
+$std->infofech->indexcapur1250 = 'S';
 
 // Schema must be decoded before it can be used for validation
 $jsonSchemaObject = json_decode($jsonSchema);

--- a/examples/schemes/v_S_01_00_00/s1299_JsonSchemaEvtFechaEvPer.php
+++ b/examples/schemes/v_S_01_00_00/s1299_JsonSchemaEvtFechaEvPer.php
@@ -68,6 +68,11 @@ $jsonSchema = '{
                     "required": false,
                     "type": ["string","null"],
                     "pattern": "^(S)$"
+                },
+                "transDCTFWeb": {
+                    "required": false,
+                    "type": ["string","null"],
+                    "pattern": "^(S)$"
                 }
             }
         }    
@@ -114,6 +119,11 @@ $std->infofech->indexcapur1250 = 'S'; //opcional
 //Indicativo de exclusão de apuração das aquisições de produção rural (eventos S-1250) do período de apuração.
 //Não informar se perApur >= [2021-05] ou se indApuracao = [2]. Preenchimento obrigatório caso o
 //campo tenha sido informado em fechamento anterior do mesmo período de apuração
+
+$std->infofech->transdctfweb = 'S'; //opcional
+// Solicitação de transmissão imediata da DCTFWeb.
+// Não informar se perApur < [2021-10]. Preenchimento obrigatório se perApur >= [2021-10] e
+// (classTrib em S-1000 = [04] ou indGuia estiver informado).
 
 
 // Schema must be decoded before it can be used for validation

--- a/jsonSchemes/v02_05_00/evtFechaEvPer.schema
+++ b/jsonSchemes/v02_05_00/evtFechaEvPer.schema
@@ -82,6 +82,11 @@
                     "required": false,
                     "type": ["string","null"],
                     "pattern": "^(19[0-9][0-9]|2[0-9][0-9][0-9])[-/](0?[1-9]|1[0-2])$"
+                },
+                "indexcapur1250": {
+                    "required": false,
+                    "type": ["string","null"],
+                    "pattern": "^(S)$"
                 }
             }
         }

--- a/jsonSchemes/v_S_01_00_00/evtFechaEvPer.schema
+++ b/jsonSchemes/v_S_01_00_00/evtFechaEvPer.schema
@@ -52,6 +52,11 @@
                     "required": false,
                     "type": ["string","null"],
                     "pattern": "^(S)$"
+                },
+                "transDCTFWeb": {
+                    "required": false,
+                    "type": ["string","null"],
+                    "pattern": "^(S)$"
                 }
             }
         }    

--- a/schemes/v02_05_00/evtFechaEvPer.xsd
+++ b/schemes/v02_05_00/evtFechaEvPer.xsd
@@ -211,8 +211,19 @@
                           <xs:documentation>Informar a primeira competência a partir da qual não houve movimento, cuja situação perdura até a competência atual</xs:documentation>
                         </xs:annotation>
                         <xs:restriction base="xs:string">
-                          <xs:length value="7"/>
-                          <xs:pattern value="[2]{1}\d{3}-(1[0-2]|0[1-9])"/>
+                          <xs:minLength value="4"/>
+                          <xs:maxLength value="7"/>
+                          <xs:pattern value="[2]{1}\d{3}-(1[0-2]|0[1-9])|[2]{1}\d{3}$"/>
+                        </xs:restriction>
+                      </xs:simpleType>
+                    </xs:element>
+                    <xs:element name="indExcApur1250" minOccurs="0">
+                      <xs:simpleType>
+                        <xs:annotation>
+                          <xs:documentation>Indicativo de exclusão de apuração das aquisições de produção rural (eventos S-1250) do período de apuração.</xs:documentation>
+                        </xs:annotation>
+                        <xs:restriction base="xs:string">
+                          <xs:pattern value="[S]"/>
                         </xs:restriction>
                       </xs:simpleType>
                     </xs:element>

--- a/schemes/v_S_01_00_00/evtFechaEvPer.xsd
+++ b/schemes/v_S_01_00_00/evtFechaEvPer.xsd
@@ -17,6 +17,7 @@
                         <xs:documentation>REGRA:REGRA_EXISTE_INFO_EMPREGADOR</xs:documentation>
                         <xs:documentation>REGRA:REGRA_REMUN_ANUAL_DEZEMBRO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_VALIDA_EMPREGADOR</xs:documentation>
+                        <xs:documentation>REGRA:REGRA_VALIDA_FAP</xs:documentation>
                         <xs:documentation>REGRA:REGRA_VALIDA_FECHAMENTO_FOPAG</xs:documentation>
                     </xs:annotation>
                     <xs:complexType>
@@ -67,7 +68,22 @@
                                                     </xs:enumeration>
                                                 </xs:restriction>
                                             </xs:simpleType>
-                                        </xs:element>                                      
+                                        </xs:element>
+                                        <xs:element name="transDCTFWeb" minOccurs="0">
+                                            <xs:simpleType>
+                                                <xs:annotation>
+                                                    <xs:documentation>Solicitação de transmissão imediata da DCTFWeb.</xs:documentation>
+                                                    <xs:documentation>Validação: Não informar se {perApur}(1299_ideEvento_perApur) &lt; [2021-10]. Preenchimento obrigatório se {perApur}(1299_ideEvento_perApur) >= [2021-10] e ({classTrib}(1000_infoEmpregador_inclusao_infoCadastro_classTrib) em S-1000 = [04] ou {indGuia}(1299_ideEvento_indGuia) estiver informado).</xs:documentation>
+                                                </xs:annotation>
+                                                <xs:restriction base="xs:string">
+                                                    <xs:enumeration value="S">
+                                                        <xs:annotation>
+                                                            <xs:documentation>Sim</xs:documentation>
+                                                        </xs:annotation>
+                                                    </xs:enumeration>
+                                                </xs:restriction>
+                                            </xs:simpleType>
+                                        </xs:element>                                        
                                     </xs:sequence>
                                 </xs:complexType>
                             </xs:element>

--- a/src/Factories/Traits/TraitS1299.php
+++ b/src/Factories/Traits/TraitS1299.php
@@ -115,6 +115,12 @@ trait TraitS1299
             ! empty($this->std->infofech->compsemmovto) ? $this->std->infofech->compsemmovto : null,
             false
         );
+        $this->dom->addChild(
+            $infoFech,
+            "indExcApur1250",
+            (($fech->indexcapur1250 ?? null) == 'S') ? $fech->indexcapur1250 : null, //aceita somente S
+            false
+        );
         $this->node->appendChild($infoFech);
         $this->eSocial->appendChild($this->node);
         //$this->xml = $this->dom->saveXML($this->eSocial);
@@ -197,7 +203,13 @@ trait TraitS1299
         $this->dom->addChild(
             $infoFech,
             "indExcApur1250",
-            ($fech->indexcapur1250 == 'S') ? $fech->indexcapur1250 : null, //aceita somente S
+            (($fech->indexcapur1250 ?? null) == 'S') ? $fech->indexcapur1250 : null, //aceita somente S
+            false
+        );
+        $this->dom->addChild(
+            $infoFech,
+            "transDCTFWeb",
+            (($fech->transdctfweb ?? null) == 'S') ? $fech->transdctfweb : null, //aceita somente S
             false
         );
         $this->node->appendChild($infoFech);


### PR DESCRIPTION
- Adicionando campo opcional transDCTFWeb no layout vS1.0
- Adicionando campo opcional indExcApur1250 no layout v2.5

O arquivo schemes/v02_05_00/evtFechaEvPer.xsd atualizado pelo site do eSocial, além de definir o campo "indExcApur1250", está alterando a validação do campo "compSemMovto" para permitir informar apenas o ano.

Essa nova validação pode trazer algum impacto negativo?
