### PR TITLE
Ajustes 2240 #367 

### DIFF
--- a/examples/Fake/v_S_01_00_00/Fake_s2240_EvtExpRisco.php
+++ b/examples/Fake/v_S_01_00_00/Fake_s2240_EvtExpRisco.php
@@ -60,15 +60,19 @@ $std->agnoc[0]->epcepi->eficepc = 'S';
 $std->agnoc[0]->epcepi->utilizepi = 1; //0 - Não se aplica; 1 - Não utilizado; 2 - Utilizado
 $std->agnoc[0]->epcepi->eficepi = 'S';
 
+
+$std->agnoc[0]->epcepi->epiCompl->medprotecao = 'S';
+$std->agnoc[0]->epcepi->epiCompl->condfuncto = 'S';
+$std->agnoc[0]->epcepi->epiCompl->usoinint = 'S';
+$std->agnoc[0]->epcepi->epiCompl->przvalid = 'S';
+$std->agnoc[0]->epcepi->epiCompl->periodictroca = 'S';
+$std->agnoc[0]->epcepi->epiCompl->higienizacao = 'S';
+
+// ou docacal (número do CA) ou descepi deve ser fornecido,
+// os dois juntos gera rejeição 
 $std->agnoc[0]->epcepi->epi[0] = new \stdClass();
-$std->agnoc[0]->epcepi->epi[0]->docaval = '111xxx';
+//$std->agnoc[0]->epcepi->epi[0]->docaval = '111xxx';
 $std->agnoc[0]->epcepi->epi[0]->dscepi = 'macacao';
-$std->agnoc[0]->epcepi->epi[0]->medprotecao = 'S';
-$std->agnoc[0]->epcepi->epi[0]->condfuncto = 'S';
-$std->agnoc[0]->epcepi->epi[0]->usoinint = 'S';
-$std->agnoc[0]->epcepi->epi[0]->przvalid = 'S';
-$std->agnoc[0]->epcepi->epi[0]->periodictroca = 'S';
-$std->agnoc[0]->epcepi->epi[0]->higienizacao = 'S';
 
 $std->respreg[0] = new \stdClass();
 $std->respreg[0]->cpfresp = '12345678901';

--- a/examples/schemes/v_S_01_00_00/s2240_JsonSchemaEvtExpRisco.php
+++ b/examples/schemes/v_S_01_00_00/s2240_JsonSchemaEvtExpRisco.php
@@ -158,6 +158,42 @@ $jsonSchema = '{
                                 "type": ["string", "null"],
                                 "pattern": "^(S|N)$"
                             },
+                            "epiCompl": {
+                                "required": false,
+                                "type": ["string","null"],
+                                "properties": {
+                                    "medprotecao": {
+                                        "required": true,
+                                        "type": "string",
+                                        "pattern": "^(S|N)$"
+                                    },
+                                    "condfuncto": {
+                                        "required": true,
+                                        "type": "string",
+                                        "pattern": "^(S|N)$"
+                                    },
+                                    "usoinint": {
+                                        "required": true,
+                                        "type": "string",
+                                        "pattern": "^(S|N)$"
+                                    },
+                                    "przvalid": {
+                                        "required": true,
+                                        "type": "string",
+                                        "pattern": "^(S|N)$"
+                                    },
+                                    "periodictroca": {
+                                        "required": true,
+                                        "type": "string",
+                                        "pattern": "^(S|N)$"
+                                    },
+                                    "higienizacao": {
+                                        "required": true,
+                                        "type": "string",
+                                        "pattern": "^(S|N)$"
+                                    }
+                                }
+                            },
                             "epi": {
                                 "required": false,
                                 "type": ["array","null"],
@@ -176,43 +212,7 @@ $jsonSchema = '{
                                             "required": false,
                                             "type": ["string","null"],
                                             "maxLength": 999
-                                        },
-                                        "epicompl": {
-                                            "required": false,
-                                            "type": ["object","null"],
-                                            "properties": {
-                                               "medprotecao": {
-                                                    "required": true,
-                                                    "type": "string",
-                                                    "pattern": "^(S|N)$"
-                                                },
-                                                "condfuncto": {
-                                                    "required": true,
-                                                    "type": "string",
-                                                    "pattern": "^(S|N)$"
-                                                },
-                                                "usoinint": {
-                                                    "required": true,
-                                                    "type": "string",
-                                                    "pattern": "^(S|N)$"
-                                                },
-                                                "przvalid": {
-                                                    "required": true,
-                                                    "type": "string",
-                                                    "pattern": "^(S|N)$"
-                                                },
-                                                "periodictroca": {
-                                                    "required": true,
-                                                    "type": "string",
-                                                    "pattern": "^(S|N)$"
-                                                },
-                                                "higienizacao": {
-                                                    "required": true,
-                                                    "type": "string",
-                                                    "pattern": "^(S|N)$"
-                                                }
-                                            }
-                                        }    
+                                        }
                                     }
                                 }
                             }    

--- a/examples/schemes/v_S_01_00_00/s2240_JsonSchemaEvtExpRisco.php
+++ b/examples/schemes/v_S_01_00_00/s2240_JsonSchemaEvtExpRisco.php
@@ -154,8 +154,8 @@ $jsonSchema = '{
                                 "maximum": 2
                             },
                             "eficepi": {
-                                "required": true,
-                                "type": "string",
+                                "required": false,
+                                "type": ["string", "null"],
                                 "pattern": "^(S|N)$"
                             },
                             "epi": {

--- a/jsonSchemes/v_S_01_00_00/evtExpRisco.schema
+++ b/jsonSchemes/v_S_01_00_00/evtExpRisco.schema
@@ -138,8 +138,8 @@
                                 "maximum": 2
                             },
                             "eficepi": {
-                                "required": true,
-                                "type": "string",
+                                "required": false,
+                                "type": ["string","null"],
                                 "pattern": "^(S|N)$"
                             },
                             "epi": {

--- a/src/Factories/Traits/TraitS2240.php
+++ b/src/Factories/Traits/TraitS2240.php
@@ -500,8 +500,8 @@ trait TraitS2240
                 $this->dom->addChild(
                     $epcEpi,
                     "eficEpi",
-                    $ag->epcepi->eficepi,
-                    true
+                    isset($ag->epcepi->eficepi) ? $ag->epcepi->eficepi : null,
+                    false
                 );
 
                 if (!empty($ag->epcepi->epi)) {

--- a/src/Factories/Traits/TraitS2240.php
+++ b/src/Factories/Traits/TraitS2240.php
@@ -507,59 +507,64 @@ trait TraitS2240
                 if (!empty($ag->epcepi->epi)) {
                     foreach ($ag->epcepi->epi as $e) {
                         $epi = $this->dom->createElement("epi");
-                        $this->dom->addChild(
-                            $epi,
-                            "docAval",
-                            isset($e->docaval) ? $e->docaval : null,
-                            false
-                        );
-                        $this->dom->addChild(
-                            $epi,
-                            "dscEPI",
-                            isset($e->dscepi) ? $e->dscepi : null,
-                            false
-                        );
+                        if(isset($e->docaval)) {
+                            $this->dom->addChild(
+                                $epi,
+                                "docAval",
+                                isset($e->docaval) ? $e->docaval : null,
+                                false
+                            );
+                        } else {
+                            $this->dom->addChild(
+                                $epi,
+                                "dscEPI",
+                                isset($e->dscepi) ? $e->dscepi : null,
+                                false
+                            );
+                        }
                         $epcEpi->appendChild($epi);
-
-                        $epiCompl = $this->dom->createElement("epiCompl");
-                        $this->dom->addChild(
-                            $epiCompl,
-                            "medProtecao",
-                            $e->medprotecao,
-                            true
-                        );
-                        $this->dom->addChild(
-                            $epiCompl,
-                            "condFuncto",
-                            $e->condfuncto,
-                            true
-                        );
-                        $this->dom->addChild(
-                            $epiCompl,
-                            "usoInint",
-                            $e->usoinint,
-                            true
-                        );
-                        $this->dom->addChild(
-                            $epiCompl,
-                            "przValid",
-                            $e->przvalid,
-                            true
-                        );
-                        $this->dom->addChild(
-                            $epiCompl,
-                            "periodicTroca",
-                            $e->periodictroca,
-                            true
-                        );
-                        $this->dom->addChild(
-                            $epiCompl,
-                            "higienizacao",
-                            $e->higienizacao,
-                            true
-                        );
-                        $epcEpi->appendChild($epiCompl);
                     }
+                }
+
+                if ($ag->epcepi->epicompl) {                    
+                    $epiCompl = $this->dom->createElement("epiCompl");
+                    $this->dom->addChild(
+                        $epiCompl,
+                        "medProtecao",
+                        $ag->epcepi->epicompl->medprotecao,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $epiCompl,
+                        "condFuncto",
+                        $ag->epcepi->epicompl->condfuncto,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $epiCompl,
+                        "usoInint",
+                        $ag->epcepi->epicompl->usoinint,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $epiCompl,
+                        "przValid",
+                        $ag->epcepi->epicompl->przvalid,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $epiCompl,
+                        "periodicTroca",
+                        $ag->epcepi->epicompl->periodictroca,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $epiCompl,
+                        "higienizacao",
+                        $ag->epcepi->epicompl->higienizacao,
+                        true
+                    );
+                    $epcEpi->appendChild($epiCompl);
                 }
                 $agNoc->appendChild($epcEpi);
             }


### PR DESCRIPTION
Correção da issue #367 :
- O campo `eficEpi` deve ser opcional conforme o manual do e-social, nos casos em que a resposta para `utilizEPI` for não `N` 
- O escopo do campo `epiCompl` não é mais por `epi ` na s_1_0_0, e sim por `agNoc`Agente nocivo. 
- Não pode ser fornecido `docaval` e `dscepi` juntos, somente um ou outro.