### PR TITLE
Atualização processo trabalhista traitS2200

### DIFF
--- a/src/Factories/Traits/TraitS2200.php
+++ b/src/Factories/Traits/TraitS2200.php
@@ -1608,12 +1608,15 @@ trait TraitS2200
                 $std->indadmissao,
                 true
             );
-            $this->dom->addChild(
-                $celetista,
-                "nrProcTrab",
-                !empty($std->nrproctrab) ? $std->nrproctrab : null,
-                true
-            );
+            // Processo judicial obrigatorio e exclusivo quando indadmissao = 3
+            if (! empty($std->nrproctrab)) {
+                $this->dom->addChild(
+                    $celetista,
+                    "nrProcTrab",
+                    $std->nrproctrab,
+                    true
+                );
+            }
              $this->dom->addChild(
                  $celetista,
                  "tpRegJor",


### PR DESCRIPTION
Número que identifica o processo trabalhista, quando a admissão se der por decisão judicial.
Validação: Informação obrigatória e exclusiva se indAdmissao = [3]. Se preenchido, deve ser um processo judicial válido, com 20 (vinte) algarismos.

[https://www.gov.br/esocial/pt-br/documentacao-tecnica/leiautes-esocial-nt-03-2021-html/index.html#2200_vinculo_infoRegimeTrab_infoCeletista_nrProcTrab](https://www.gov.br/esocial/pt-br/documentacao-tecnica/leiautes-esocial-nt-03-2021-html/index.html#2200_vinculo_infoRegimeTrab_infoCeletista_nrProcTrab)