### PR TITLE
[FIX] #390 - S 1.0 - Ajuste obrigatoriedade respMonit

### DIFF
--- a/jsonSchemes/v_S_01_00_00/evtMonit.schema
+++ b/jsonSchemes/v_S_01_00_00/evtMonit.schema
@@ -132,8 +132,8 @@
                 }  
             },
             "respmonit": {
-                "required": true,
-                "type": "object",
+                "required": false,
+                "type": ["object", "null"],
                 "properties": {
                     "cpfresp": {
                         "required": false,

--- a/src/Factories/Traits/TraitS2220.php
+++ b/src/Factories/Traits/TraitS2220.php
@@ -468,32 +468,34 @@ trait TraitS2220
         $exMedOcup->appendChild($aso);
 
         $stdmon = $this->std->exmedocup->respmonit;
-        $monit = $this->dom->createElement("respMonit");
-        $this->dom->addChild(
-            $monit,
-            "cpfResp",
-            !empty($stdmon->cpfresp) ? $stdmon->cpfresp : null,
-            false
-        );
-        $this->dom->addChild(
-            $monit,
-            "nmResp",
-            $stdmon->nmresp,
-            true
-        );
-        $this->dom->addChild(
-            $monit,
-            "nrCRM",
-            $stdmon->nrcrm,
-            true
-        );
-        $this->dom->addChild(
-            $monit,
-            "ufCRM",
-            $stdmon->ufcrm,
-            true
-        );
-        $exMedOcup->appendChild($monit);
+        if(!empty($stdmon)) {
+            $monit = $this->dom->createElement("respMonit");
+            $this->dom->addChild(
+                $monit,
+                "cpfResp",
+                !empty($stdmon->cpfresp) ? $stdmon->cpfresp : null,
+                false
+            );
+            $this->dom->addChild(
+                $monit,
+                "nmResp",
+                $stdmon->nmresp,
+                true
+            );
+            $this->dom->addChild(
+                $monit,
+                "nrCRM",
+                $stdmon->nrcrm,
+                true
+            );
+            $this->dom->addChild(
+                $monit,
+                "ufCRM",
+                $stdmon->ufcrm,
+                true
+            );
+            $exMedOcup->appendChild($monit);
+        }
         $this->node->appendChild($exMedOcup);
         
         //finalização do xml


### PR DESCRIPTION
Seguindo o manual da versão S 1.0:  

> 1.7. O grupo [respMonit] é de preenchimento obrigatório sempre que houver um médico
responsável/coordenador do PCMSO. Inexistindo obrigatoriedade de elaboração do PCMSO, o campo
não precisa ser preenchido.

Ajuste no código da versão S 1.0