### PR TITLE
ISSUE #439 - correção do campo tpContr onde possui 3 opções de resposta.

### DIFF
--- a/examples/schemes/v02_05_00/s2200_JsonSchemaEvtAdmissao.php
+++ b/examples/schemes/v02_05_00/s2200_JsonSchemaEvtAdmissao.php
@@ -804,7 +804,7 @@ $jsonSchema = '{
                             "required": true,
                             "type": "integer",
                             "minimum": 1,
-                            "maximum": 2
+                            "maximum": 3
                         },
                         "dtterm": {
                             "required": false,

--- a/examples/schemes/v_S_01_00_00/s2206_JsonSchemaEvtAltContratual.php
+++ b/examples/schemes/v_S_01_00_00/s2206_JsonSchemaEvtAltContratual.php
@@ -201,7 +201,7 @@ $jsonSchema = '{
                     "required": true,
                     "type": "integer",
                     "minimum": 1,
-                    "maximum": 2
+                    "maximum": 3
                 },
                 "dtterm": {
                     "required": false,

--- a/jsonSchemes/v02_05_00/evtAdmissao.schema
+++ b/jsonSchemes/v02_05_00/evtAdmissao.schema
@@ -782,7 +782,7 @@
                             "required": true,
                             "type": "integer",
                             "minimum": 1,
-                            "maximum": 2
+                            "maximum": 3
                         },
                         "dtterm": {
                             "required": false,

--- a/jsonSchemes/v_S_01_00_00/evtAltContratual.schema
+++ b/jsonSchemes/v_S_01_00_00/evtAltContratual.schema
@@ -186,7 +186,7 @@
                     "required": true,
                     "type": "integer",
                     "minimum": 1,
-                    "maximum": 2
+                    "maximum": 3
                 },
                 "dtterm": {
                     "required": false,


### PR DESCRIPTION
Feita, correção no campo "tpContr", nas ocorrências encontradas no projeto. 
A alteração vale tanto para o evento S2200 'evtAdmissao", quanto para o evento S2206  "evtAltContratual", pois se trata da mesma condição.

tpContr	[duracao]	- Tipo de contrato de trabalho.
Valores válidos:
1 - Prazo indeterminado
2 - Prazo determinado, definido em dias
3 - Prazo determinado, vinculado à ocorrência de um fato