### PR TITLE
Validação de cpfresp - S2240 #447

### DIFF
--- a/jsonSchemes/v_S_01_00_00/evtExpRisco.schema
+++ b/jsonSchemes/v_S_01_00_00/evtExpRisco.schema
@@ -215,7 +215,7 @@
                 "type": "object",
                 "properties": {
                     "cpfresp": {
-                        "required": true,
+                        "required": false,
                         "type": "string",
                         "pattern": "^[0-9]{11}$"
                     },

--- a/src/Factories/Traits/TraitS2240.php
+++ b/src/Factories/Traits/TraitS2240.php
@@ -573,12 +573,16 @@ trait TraitS2240
 
         foreach ($this->std->respreg as $r) {
             $respReg = $this->dom->createElement("respReg");
-            $this->dom->addChild(
-                $respReg,
-                "cpfResp",
-                $r->cpfresp,
-                true
-            );
+
+            if(!empty($r->cpfresp)){
+                $this->dom->addChild(
+                    $respReg,
+                    "cpfResp",
+                    $r->cpfresp,
+                    true
+                );
+            }
+            
             $this->dom->addChild(
                 $respReg,
                 "ideOC",


### PR DESCRIPTION
O campo cpfresp na versão S1.0 não é obrigatório conforme mostra em https://www.gov.br/esocial/pt-br/documentacao-tecnica/leiautes-esocial-nt-06-2022-html/index.html/#evtExpRisco
