### PR TITLE
#455 - Retirando obrigatoriedades dos campos vrsalfx undsalfixo tpcon…

### DIFF
--- a/examples/schemes/v_S_01_00_00/s2206_JsonSchemaEvtAltContratual.php
+++ b/examples/schemes/v_S_01_00_00/s2206_JsonSchemaEvtAltContratual.php
@@ -183,11 +183,11 @@ $jsonSchema = '{
                       "maximum": 905
                 },
                 "vrsalfx": {
-                    "required": true,
+                    "required": false,
                     "type": "number"
                 },
                 "undsalfixo": {
-                    "required": true,
+                    "required": false,
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 7
@@ -198,7 +198,7 @@ $jsonSchema = '{
                     "maxLength": 255
                 },
                 "tpcontr": {
-                    "required": true,
+                    "required": false,
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 2

--- a/jsonSchemes/v_S_01_00_00/evtAltContratual.schema
+++ b/jsonSchemes/v_S_01_00_00/evtAltContratual.schema
@@ -168,11 +168,11 @@
                       "maximum": 905
                 },
                 "vrsalfx": {
-                    "required": true,
+                    "required": false,
                     "type": "number"
                 },
                 "undsalfixo": {
-                    "required": true,
+                    "required": false,
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 7
@@ -183,7 +183,7 @@
                     "maxLength": 255
                 },
                 "tpcontr": {
-                    "required": true,
+                    "required": false,
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 2


### PR DESCRIPTION
#454 - Retirando obrigatoriedades dos campos vrsalfx undsalfixo tpcontr para antender as atualização da ISSUE 454.

Peço desculpas, acabou passando batido. 

Esto com uma situação ainda no 2206, tenho um colaborador que enquadra na condição não da regra abaixo, porém mesmo mitigando o envio da tag <infoRegimeTrab/> ele ainda apresenta erro, fiz um teste retirando a tag por completo ele apresenta um erro de retorno do esocial solicitando os dados do infoRegimeTrab, você teria alguma luz ?

infoEstatutario | infoRegimeTrab | 6 | Informações de trabalhador estatutário | 0-1 | - | O (se tpRegPrev = [2] e tpRegTrab em S-2200 = [2]); N (nos demais casos)

Erro apresentado enviando somente a tag <infoRegimeTrab/> sem os dados.
Grupo 'Informações do regime trabalhista' não deve ser preenchido. Verifique as condições de preenchimento no leiaute