### PR TITLE
Ajustado epcepi como opcional para envio de evento com ausência de ag…

### DIFF
--- a/jsonSchemes/v_S_01_00_00/evtExpRisco.schema
+++ b/jsonSchemes/v_S_01_00_00/evtExpRisco.schema
@@ -117,7 +117,7 @@
                         "maxLength": 40
                     },
                     "epcepi": {
-                        "required": true,
+                        "required": false,
                         "type": "object",
                         "properties": {
                             "utilizepc": {
@@ -199,10 +199,10 @@
                                         }
                                     }
                                 }
-                            }    
+                            }
                         }
                     }
-                }    
+                }
             }
         },
         "respreg": {
@@ -241,12 +241,12 @@
                         "pattern": "^.{2}$"
                     }
                 }
-            }    
+            }
         },
         "obscompl": {
             "required": false,
             "type": ["string","null"],
             "pattern": "^.{2,999}$"
         }
-    }    
+    }
 }

--- a/jsonSchemes/v_S_01_00_00/evtExpRisco.schema
+++ b/jsonSchemes/v_S_01_00_00/evtExpRisco.schema
@@ -118,7 +118,7 @@
                     },
                     "epcepi": {
                         "required": false,
-                        "type": "object",
+                        "type": ["object","null"],
                         "properties": {
                             "utilizepc": {
                                "required": true,


### PR DESCRIPTION
…ente nocivo (09.01.001) closes#467

O epcepi é opcional, o evento com ausência de agente nocivo (codagnoc = 09.01.001) não podem adicionar tag epcepi pois gera a seguinte ocorrência "código: 553 - Grupo 'Informações relativas a Equipamentos de Proteção Coletiva - EPC e Equipamentos de Proteção Individual - EPI' não deve ser preenchido. Verifique as condições de preenchimento no leiaute."