### PR TITLE
Evento 2206 - Correção nos valores aceitos de acordo com o layout 1.1 do e-social para o campo tpplanrp

### DIFF
--- a/jsonSchemes/v_S_01_01_00/evtAltContratual.schema
+++ b/jsonSchemes/v_S_01_01_00/evtAltContratual.schema
@@ -117,8 +117,8 @@
                 "tpplanrp": {
                     "required": true,
                     "type": "integer",
-                    "minimum": 1,
-                    "maximum": 2
+                    "minimum": 0,
+                    "maximum": 3
                 },
                 "indtetorgps": {
                     "required": true,


### PR DESCRIPTION
https://www.gov.br/esocial/pt-br/documentacao-tecnica/manuais/leiautes-esocial-v-1-1-beta/index.html#evtAltContratual

tpPlanRP pode ter os seguintes valores: 0,1,2,3