### PR TITLE
Ajuste nos itens de remuneração do elemento "remunPerAnt"

### DIFF
--- a/src/Factories/Traits/TraitS1202.php
+++ b/src/Factories/Traits/TraitS1202.php
@@ -336,7 +336,7 @@ trait TraitS1202
                                 !empty($rpa->matricula) ? $rpa->matricula : null,
                                 false
                             );
-                            foreach ($rem->itensremun as $item) {
+                            foreach ($rpa->itensremum as $item) {
                                 $itemrpa = $this->dom->createElement("itensRemun");
                                 $this->dom->addChild(
                                     $itemrpa,
@@ -698,7 +698,7 @@ trait TraitS1202
                                 !empty($rpa->matricula) ? $rpa->matricula : null,
                                 false
                             );
-                            foreach ($rem->itensremun as $item) {
+                            foreach ($rpa->itensremum as $item) {
                                 $itemrpa = $this->dom->createElement("itensRemun");
                                 $this->dom->addChild(
                                     $itemrpa,


### PR DESCRIPTION
nfephp-org#497 - issue

Ajuste da referência aos itens de remuneração anteriores. A classe estava sempre referenciando os itens de remuneração de período de apuração atual.