### PR TITLE
Correção de BUG no nome do evento de 2400

### DIFF
--- a/src/Event.php
+++ b/src/Event.php
@@ -182,7 +182,7 @@ class Event
         'evtTSVInicio' => 'S-2300',
         'evtTSVAltContr' => 'S-2306',
         'evtTSVTermino' => 'S-2399',
-        'evtCdBenefIn ' => 'S-2400',
+        'evtCdBenefIn' => 'S-2400',
         'evtCdBenefAlt' => 'S-2405',
         'evtCdBenIn' => 'S-2410',
         'evtCdBenAlt' => 'S-2416',


### PR DESCRIPTION
Ao realizar uma tentativa de envio do evento S2400, estava recebendo o seguinte erro: 

`
  "class": "RuntimeException",
    "message": "Falha na localização do ID do evento.",
    "code": 0,
    "file": "/var/www/html/vendor/nfephp-org/sped-esocial/src/Tools.php:669",
`

Ao debugar o código, constatei junto ao time interno que havia um espaço vazio sobrando no nome relativo ao evento S2400, o que fazia com que o id do XML na classe tools não pudesse ser encontrado e por consequência, o envio não era feito, fiz a correção localmente e o resultado foi o envio do evento com sucesso.