### PR TITLE
fix: correção garantir obtenção do evento id

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -800,6 +800,9 @@ class Tools extends ToolsBase
         foreach ($keys as $tagname) {
             if (!empty($dom->getElementsByTagName($tagname)->item(0))) {
                 $tag = $dom->getElementsByTagName($tagname)->item(0);
+                if (empty($tag->getAttribute('Id'))) {
+                    continue;
+                }
                 $id = $tag->getAttribute('Id');
                 $code = $possibles[$tagname];
                 $grupo = $this->groupbycode[$code];


### PR DESCRIPTION
Adicionando uma validação no método getIdFromXml($xml), pois o evento s1299 (evtFechaEvPer) não esta obtendo o campo Id do XML.
O evento possui os seguintes campos:

```xml
<infoFech>
    <evtRemun>S</evtRemun>
    <evtPgtos>S</evtPgtos>
    <evtComProd>N</evtComProd>
    <evtContratAvNP>N</evtContratAvNP>
</infoFech>
```

E ao entrar na condição:
```
if (!empty($dom->getElementsByTagName($tagname)->item(0))) {
```

E neste evento esta obtendo o primeiro item que encontrar com **$tagname** no XML. Como por exemplo o **evtRemun**, mas este campo no xml nao possui nenhum ID, pois ele é um campo de **infoFech**

Com a adição da nova condição, seguirá o processo até encontrar o evtFechaEvPer, onde possui o Id do evento.

