### PR TITLE
Update evtCdBenefAlt.schema

### DIFF
--- a/jsonSchemes/v_S_01_01_00/evtCdBenefAlt.schema
+++ b/jsonSchemes/v_S_01_01_00/evtCdBenefAlt.schema
@@ -50,8 +50,8 @@
                     "maximum": 6
                 },
                 "estciv": {
-                    "required": true,
-                    "type": "integer",
+                    "required": false,
+                    "type": ["integer","null"],
                     "minimum": 1,
                     "maximum": 5
                 },


### PR DESCRIPTION
#508

A configuração do campo estCiv está marcada como campo obrigatório, apesar da documentação oficial apresentar o campo como facultativo.