### PR TITLE
Update TraitS2231.php

### DIFF
--- a/src/Factories/Traits/TraitS2231.php
+++ b/src/Factories/Traits/TraitS2231.php
@@ -85,7 +85,7 @@ trait TraitS2231
             $fim = $this->dom->createElement("fimCessao");
             $this->dom->addChild(
                 $fim,
-                "dtTermCesssao",
+                "dtTermCessao",
                 $this->std->fimcessao->dttermcessao,
                 true
             );


### PR DESCRIPTION
FIX
Evento S2231
Ajuste na grafia do elemento dtTermCessao

Element '{http://www.esocial.gov.br/schema/evt/evtCessao/v_S_01_02_00}dtTermCesssao': This element is not expected. Expected is ( {http://www.esocial.gov.br/schema/evt/evtCessao/v_S_01_02_00}dtTermCessao ).