### PR TITLE
Ajuste s2205_JsonSchemaEvtAltCadastral descrdep

### DIFF
--- a/examples/schemes/v_S_01_02_00/s2205_JsonSchemaEvtAltCadastral.php
+++ b/examples/schemes/v_S_01_02_00/s2205_JsonSchemaEvtAltCadastral.php
@@ -292,7 +292,7 @@ $jsonSchema = '{
                         "pattern": "^(S|N)$"
                     },
                     "descrdep": {
-                        "required": true,
+                        "required": false,
                         "type": "string",
                         "minLength": 1,
                         "maxLength": 100


### PR DESCRIPTION
O campo descrdep, só é obrigatório quando tpDep = 99.