### PR TITLE
Implementação do Novo XSD InfoEmpregador S_1_2_0 para Indicativo de desoneração da folha.

### DIFF
--- a/jsonSchemes/v_S_01_02_00/evtInfoEmpregador.schema
+++ b/jsonSchemes/v_S_01_02_00/evtInfoEmpregador.schema
@@ -54,7 +54,7 @@
                     "required": true,
                     "type": "integer",
                     "minimum": 0,
-                    "maximum": 1
+                    "maximum": 2
                 },
                 "indopccp": {
                     "required": false,

--- a/schemes/v_S_01_02_00/evtInfoEmpregador.xsd
+++ b/schemes/v_S_01_02_00/evtInfoEmpregador.xsd
@@ -145,8 +145,8 @@
             <xs:element name="indDesFolha">
                 <xs:simpleType>
                     <xs:annotation>
-                        <xs:documentation>Indicativo de desoneração da folha.</xs:documentation>
-                        <xs:documentation>Validação: Pode ser igual a [1] apenas se {classTrib}(./classTrib) = [02, 03, 99]. Nos demais casos, deve ser igual a [0].</xs:documentation>
+                        <xs:documentation>Indicativo de opção/enquadramento de desoneração da folha.</xs:documentation>
+                        <xs:documentation>Validação: Pode ser igual a [1] apenas se {classTrib}(./classTrib) = [02, 03, 99]. Pode ser igual a [2] apenas para as naturezas jurídicas iguais a [103-1, 106-6, 124-4, 133-3]. Nos demais casos, deve ser igual a [0].</xs:documentation>
                     </xs:annotation>
                     <xs:restriction base="xs:byte">
                         <xs:enumeration value="0">
@@ -156,7 +156,12 @@
                         </xs:enumeration>
                         <xs:enumeration value="1">
                             <xs:annotation>
-                                <xs:documentation>Empresa enquadrada nos arts. 7º a 9º da Lei 12.546/2011</xs:documentation>
+                                <xs:documentation>Empresa enquadrada nos critérios da legislação vigente</xs:documentation>
+                            </xs:annotation>
+                        </xs:enumeration>
+                        <xs:enumeration value="2">
+                            <xs:annotation>
+                                <xs:documentation>Município enquadrado nos critérios da legislação vigente</xs:documentation>
                             </xs:annotation>
                         </xs:enumeration>
                     </xs:restriction>
@@ -227,13 +232,14 @@
                 <xs:annotation>
                     <xs:documentation>Data da transformação em sociedade de fins lucrativos - Lei 11.096/2005.</xs:documentation>
                     <xs:documentation>Validação: Não preencher se {classTrib}(./classTrib) = [21, 22].</xs:documentation>
+                    <xs:documentation>Se informada, deve ser maior que [2005-11-21] e menor ou igual à data atual.</xs:documentation>
                 </xs:annotation>
             </xs:element>
             <xs:element name="indTribFolhaPisCofins" minOccurs="0">
                 <xs:simpleType>
                     <xs:annotation>
-                        <xs:documentation>Indicador de tributação sobre a folha de pagamento - PIS e COFINS.</xs:documentation>
-                        <xs:documentation>Preenchimento exclusivo para o empregador em situação de tributação de PIS e COFINS sobre a folha de pagamento.</xs:documentation>
+                        <xs:documentation>Indicador de tributação sobre a folha de pagamento - PIS e PASEP.</xs:documentation>
+                        <xs:documentation>Preenchimento exclusivo para o empregador em situação de tributação de PIS e PASEP sobre a folha de pagamento.</xs:documentation>
                     </xs:annotation>
                     <xs:restriction base="xs:string">
                         <xs:enumeration value="S">


### PR DESCRIPTION
Olá @robmachado, tudo bem?
Segue implementação do Novo XSD InfoEmpregador que foi disponibilizado hoje 01/02/2024 na versão S_1_2_0 para Indicativo de desoneração da folha.