### PR TITLE
Update evtCdBenefAlt.schema

### DIFF
--- a/jsonSchemes/v_S_01_02_00/evtCdBenefAlt.schema
+++ b/jsonSchemes/v_S_01_02_00/evtCdBenefAlt.schema
@@ -50,8 +50,8 @@
                     "maximum": 6
                 },
                 "estciv": {
-                    "required": true,
-                    "type": "integer",
+                    "required": false,
+                    "type": ["integer","null"],
                     "minimum": 1,
                     "maximum": 5
                 },


### PR DESCRIPTION
Conforme documentação técnica, pode ser informado nulo no campo estCiv do evento S2405.