### PR TITLE
Update TraitS2200.php

### DIFF
--- a/src/Factories/Traits/TraitS2200.php
+++ b/src/Factories/Traits/TraitS2200.php
@@ -1511,14 +1511,14 @@ trait TraitS2200
                 $this->dom->addChild(
                     $aprendiz,
                     "tpInsc",
-                    $std->aprend->tpinsc,
-                    true
+                    $std->aprend->tpinsc ?? null,
+                    false
                 );
                 $this->dom->addChild(
                     $aprendiz,
                     "nrInsc",
-                    $std->aprend->nrinsc,
-                    true
+                    $std->aprend->nrinsc ?? null,
+                    false
                 );
                 $this->dom->addChild(
                     $aprendiz,


### PR DESCRIPTION
Alterado obrigatoriedade dos campos tpinsc e nrinsc para jovens aprendizes, os campos só deve ser preenchido quando indAprend = 2.