### PR TITLE
Fix nrProcRRA - XML do evento S1207

### DIFF
--- a/src/Factories/Traits/TraitS1207.php
+++ b/src/Factories/Traits/TraitS1207.php
@@ -309,8 +309,8 @@ trait TraitS1207
                 $this->dom->addChild(
                     $rra,
                     "nrProcRRA",
-                    $irra->nrprocrra,
-                    true
+                    $irra->nrprocrra ?? null,
+                    false
                 );
                 $this->dom->addChild(
                     $rra,


### PR DESCRIPTION
Ao não informar o valor nrProcRRA, deve-se remover esse atributo do XML para que seja possível recepcionar o evento na base do e-social.

Ao informar o atributo nulo, a biblioteca retorna a mensagem "Undefined property: stdClass::$nrprocrra"