### PR TITLE
TraitS1210.php - [tpdep] Campo não obrigatório

### DIFF
--- a/src/Factories/Traits/TraitS1210.php
+++ b/src/Factories/Traits/TraitS1210.php
@@ -1100,7 +1100,7 @@ trait TraitS1210
                             $dep->tpdep ?? null,
                             false
                         );
-                        if ($dep->tpdep === '99') {
+                        if (!empty($dep->tpdep) && $dep->tpdep === '99') {
                             $this->dom->addChild(
                                 $infodep,
                                 "descrDep",


### PR DESCRIPTION
Preenchimento obrigatório e exclusivo se depIRRF = [S], comparação sendo realizada mesmo com campo inexistente, causando erro ao montar o xml