### PR TITLE
Adiciona suporte para a tabela de processos judiciais relativos a contribuição para o PIS/PASEP, incluindo novos campos no schema e exemplos. Implementa a lógica para manipulação dos dados no TraitS1010.

### DIFF
--- a/docs/EvtTabRubrica.md
+++ b/docs/EvtTabRubrica.md
@@ -103,6 +103,14 @@ Diante disso, alertamos para a necessidade de um profissional qualificado para o
 |id|integer|id da tabela|
 |nrProc|string|Informar um número de processo cadastrado através do evento S-1070, cujo {indMatProc} seja igual a [8]|
 
+### Table: rubricasprocpispasep - tabela de processos judiciais relativos a contribuição para o PIS/PASEP
+
+|field|type|comment|
+|:---|:---:|:---|
+|id|integer|id da tabela|
+|nrProc|string|Informar um número de processo cadastrado através do evento S-1070, cujo {indMatProc} seja igual a [1].|
+|codSusp|string|Código do Indicativo da Suspensão, atribuído pelo empregador em S-1070|
+
 ## Parâmetros
 O stdClass deve ser carregado com os seguintes parâmetros:
 

--- a/examples/Fake/v_S_01_03_00/Fake_s1010_EvtTabRubrica.php
+++ b/examples/Fake/v_S_01_03_00/Fake_s1010_EvtTabRubrica.php
@@ -65,6 +65,10 @@ $std->dadosrubrica->ideprocessoirrf[0]->codsusp = '0929292882';
 $std->dadosrubrica->ideprocessofgts[0] = new \stdClass();
 $std->dadosrubrica->ideprocessofgts[0]->nrproc  = 'asdfghjkliuytrewqasd';
 
+//campo ARRAY opcional
+$std->dadosrubrica->ideprocessopispasep[0] = new \stdClass();
+$std->dadosrubrica->ideprocessopispasep[0]->nrproc  = 'asdfghjkliuytrewqasd';
+$std->dadosrubrica->ideprocessopispasep[0]->codsusp = '0929292882';
 
 //campos opcionais usar apenas em alterações
 $std->novavalidade = new \stdClass();

--- a/examples/schemes/v_S_01_03_00/s1010_JsonSchemaEvtTabRubrica.php
+++ b/examples/schemes/v_S_01_03_00/s1010_JsonSchemaEvtTabRubrica.php
@@ -174,6 +174,27 @@ $jsonSchema = '{
                             }
                         }
                     }
+                },
+                "ideprocessopispasep": {
+                    "required": false,
+                    "type": ["array","null"],
+                    "minItems": 0,
+                    "maxItems": 99,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "nrproc": {
+                                "required": true,
+                                "type": "string",
+                                "$ref": "#/definitions/string20"
+                            },
+                            "codsusp": {
+                                "required": true,
+                                "type": "string",
+                                "pattern": "^[0-9]{1,14}$"
+                            }
+                        }
+                    }
                 }
             }
         },
@@ -233,6 +254,10 @@ $std->dadosrubrica->ideprocessoirrf[0]->codsusp = '0929292882';
 $std->dadosrubrica->ideprocessofgts[0] = new \stdClass();
 $std->dadosrubrica->ideprocessofgts[0]->nrproc  = 'asdfghjkliuytrewqasd';
 
+//campo ARRAY opcional
+$std->dadosrubrica->ideprocessopispasep[0] = new \stdClass();
+$std->dadosrubrica->ideprocessopispasep[0]->nrproc  = 'asdfghjkliuytrewqasd';
+$std->dadosrubrica->ideprocessopispasep[0]->codsusp = '0929292882';
 
 //campos opcionais usar apenas em alterações
 $std->novavalidade = new \stdClass();

--- a/jsonSchemes/v_S_01_03_00/evtTabRubrica.schema
+++ b/jsonSchemes/v_S_01_03_00/evtTabRubrica.schema
@@ -158,6 +158,27 @@
                             }
                         }
                     }
+                },
+                "ideprocessopispasep": {
+                    "required": false,
+                    "type": ["array","null"],
+                    "minItems": 0,
+                    "maxItems": 99,
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "nrproc": {
+                                "required": true,
+                                "type": "string",
+                                "$ref": "#/definitions/string20"
+                            },
+                            "codsusp": {
+                                "required": true,
+                                "type": "string",
+                                "pattern": "^[0-9]{1,14}$"
+                            }
+                        }
+                    }
                 }
             }
         },

--- a/src/Factories/Traits/TraitS1010.php
+++ b/src/Factories/Traits/TraitS1010.php
@@ -193,6 +193,24 @@ trait TraitS1010
                     $dadosRubrica->appendChild($ideProcessoFGTS);
                 }
             }
+            if (! empty($this->std->dadosrubrica->ideprocessopispasep)) {
+                foreach ($this->std->dadosrubrica->ideprocessopispasep as $pispasep) {
+                    $ideProcessoPisPasep = $this->dom->createElement("ideProcessoPisPasep");
+                    $this->dom->addChild(
+                        $ideProcessoPisPasep,
+                        "nrProc",
+                        $pispasep->nrproc,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $ideProcessoPisPasep,
+                        "codSusp",
+                        $pispasep->codsusp,
+                        true
+                    );
+                    $dadosRubrica->appendChild($ideProcessoPisPasep);
+                }
+            }
             if (! empty($this->std->dadosrubrica->ideprocessosind)) {
                 foreach ($this->std->dadosrubrica->ideprocessosind as $sind) {
                     $ideProcessoSIND = $this->dom->createElement("ideProcessoSIND");
@@ -442,6 +460,24 @@ trait TraitS1010
                         true
                     );
                     $dadosRubrica->appendChild($ideProcessoFGTS);
+                }
+            }
+            if (! empty($this->std->dadosrubrica->ideprocessopispasep)) {
+                foreach ($this->std->dadosrubrica->ideprocessopispasep as $pispasep) {
+                    $ideProcessoPisPasep = $this->dom->createElement("ideProcessoPisPasep");
+                    $this->dom->addChild(
+                        $ideProcessoPisPasep,
+                        "nrProc",
+                        $pispasep->nrproc,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $ideProcessoPisPasep,
+                        "codSusp",
+                        $pispasep->codsusp,
+                        true
+                    );
+                    $dadosRubrica->appendChild($ideProcessoPisPasep);
                 }
             }
             if (! empty($this->std->dadosrubrica->ideprocessosind)) {


### PR DESCRIPTION
Adiciona suporte para a tabela de processos judiciais relativos a contribuição para o PIS/PASEP, incluindo novos campos no schema e exemplos. Implementa a lógica para manipulação dos dados no TraitS1010.

Exemplo do novo nó do XML:
```xml
                   <ideProcessoPisPasep>
                        <nrProc>asdfghjkliuytrewqasd</nrProc>
                        <codSusp>0929292882</codSusp>
                    </ideProcessoPisPasep>
```