### PR TITLE
FIX evtExpRisco campo tpAval

### DIFF
--- a/jsonSchemes/v_S_01_03_00/evtExpRisco.schema
+++ b/jsonSchemes/v_S_01_03_00/evtExpRisco.schema
@@ -98,7 +98,7 @@
                     },
                     "tpaval": {
                         "required": false,
-                        "type": "integer",
+                        "type": ["integer","null"],
                         "minimum": 1,
                         "maximum": 2
                     },


### PR DESCRIPTION
Ajuste para aceitar valores nulos.

Validação conforme documentação: Preenchimento obrigatório e exclusivo se tpAval = [1] e codAgNoc = [01.18.001, 02.01.014].