### PR TITLE
feat(v_S_01_03_00): NT S-1.3 nº 06/2026

### DIFF
--- a/docs/EvtCdBenAlt.md
+++ b/docs/EvtCdBenAlt.md
@@ -1,0 +1,14 @@
+# EvtCdBenAlt
+
+## Evento
+*evtCdBenAlt* — S-2416 Cadastro de Benefício - Alteração (Entes Públicos)
+
+## Alterações v_S_01_03_00 (NT S-1.3 nº 06/2026)
+
+### Grupo `instPenMorte` em `infoPenMorte` (novo no S130)
+- **Localização:** `infoBenAlteracao/dadosBeneficio/infoPenMorte/instPenMorte`
+- **Obrigatoriedade do grupo:** Opcional — se não informado e `dtAltBeneficio >= 2025-11-24`, retorna alerta.
+- **Campos:**
+  - `tpDepInst` (obrigatório dentro do grupo): Tipo de dependente do instituidor (`TS_tpDepInst`)
+  - `descrDepInst` (opcional): Descrição complementar do tipo de dependente (`TS_descrDepInst`)
+- **Diferença em relação ao S-2410:** Em S-2416, `instPenMorte` contém **apenas** `tpDepInst` e `descrDepInst` (sem `cpfInst`/`dtInst`, que são exclusivos do S-2410).

--- a/docs/EvtCdBenIn.md
+++ b/docs/EvtCdBenIn.md
@@ -163,3 +163,8 @@ try {
 - O nó `infoHomolog` é **exclusivo do layout v_S_01_03_00** (versão 1.3). Em versões anteriores o campo é ignorado.
 - Dentro do grupo `infoHomolog`, o campo `sitHomolog` é obrigatório. O campo `dtHomolog` é opcional.
 - Valores válidos para `sitHomolog`: `0`, `1`, `2`.
+
+### Campos `tpDepInst` e `descrDepInst` em `instPenMorte` (novos no S130)
+- **Localização:** `infoBenInicio/dadosBeneficio/infoPenMorte/instPenMorte/tpDepInst` e `descrDepInst`
+- **`tpDepInst`:** Opcional (`TS_tpDepInst`) — Tipo de dependente do instituidor da pensão por morte.
+- **`descrDepInst`:** Opcional (`TS_descrDepInst`) — Descrição complementar do tipo de dependente.

--- a/docs/EvtDeslig.md
+++ b/docs/EvtDeslig.md
@@ -69,3 +69,16 @@ A classe pode retornar: string XML, string JSON ou array com os dados
 </eSocial>
 
 ```
+
+## Alterações v_S_01_03_00 (NT S-1.3 nº 06/2026)
+
+### Campo `notAFT` (novo)
+- **Localização:** `infoDeslig/verbasResc/dmDev/notAFT`
+- **Tipo:** `TS_notAFT` — 9 caracteres alfanuméricos (`[A-Za-z0-9]{9}`)
+- **Obrigatoriedade:** Opcional
+- **Descrição:** Número da notificação do FGTS Digital que originou a confissão. Se informado, `infoPerAnt` não pode ser preenchido.
+
+### Campo `descFolha` em `detVerbas` (já suportado)
+- **Localização:** `infoDeslig/verbasResc/dmDev/infoPerApur/ideEstabLot/detVerbas/descFolha`
+- **Tipo:** `T_descFolha` — grupo eConsignado
+- **Obrigatoriedade:** Opcional

--- a/docs/EvtProcTrab.md
+++ b/docs/EvtProcTrab.md
@@ -1,0 +1,22 @@
+# EvtProcTrab
+
+## Evento
+*evtProcTrab* — S-2500 Processo Trabalhista
+
+## Alterações v_S_01_03_00 (NT S-1.3 nº 06/2026)
+
+### Campo `infoPatPrec` (novo no S130)
+- **Localização:** `infoProcesso/dadosCompl/infoProcJud/infoPatPrec`
+- **Tipo:** `TS_valorMonetario` — valor monetário
+- **Obrigatoriedade:** Obrigatório e exclusivo se `origem = 3` (Justiça Comum)
+- **Descrição:** Valor total da cota patronal incidente sobre a remuneração paga ao trabalhador, que será objeto de requisição autônoma.
+
+### Suporte a `origem = 3` (Justiça Comum)
+- O enum `TS_origem` ganhou o valor `3` = Justiça Comum.
+- Quando `origem = 3`, o grupo `infoProcJud` é obrigatório (igual ao `origem = 1`).
+- A validação do `nrProcTrab` para `origem = 3`: o 14º dígito deve ser `4` ou `8` (se `dtSent >= 2026-04-27`).
+
+### Campos `indCateg` e `indNatAtiv` em `infoContr`
+- Estes campos já existiam desde S-1.2.0 ao nível de `infoContr`.
+- Controlam respectivamente se houve reconhecimento de categoria e de natureza de atividade diferentes das informadas pelo declarante.
+- O grupo `mudCategAtiv` é obrigatório quando `indCateg = S` ou `indNatAtiv = S`.

--- a/docs/EvtRemun.md
+++ b/docs/EvtRemun.md
@@ -66,3 +66,16 @@ A classe pode retornar: string XML, string JSON ou array com os dados
 </eSocial>
 
 ```
+
+## Alterações v_S_01_03_00 (NT S-1.3 nº 06/2026)
+
+### Campo `notAFT` (novo)
+- **Localização:** `dmDev/notAFT`
+- **Tipo:** `TS_notAFT` — 9 caracteres alfanuméricos (`[A-Za-z0-9]{9}`)
+- **Obrigatoriedade:** Opcional
+- **Descrição:** Número da notificação do FGTS Digital que originou a confissão de débito. Só pode ser preenchido se o mês/ano de `perApur` for igual ou posterior ao início do FGTS Digital.
+
+### Campo `descFolha` em `itensRemun` (já suportado)
+- **Localização:** `dmDev/infoPerApur/ideEstabLot/remunPerApur/itensRemun/descFolha`
+- **Tipo:** `T_descFolha` — grupo eConsignado com `tpDesc`, `instFinanc`, `nrDoc`, `observacao?`
+- **Obrigatoriedade:** Opcional — exclusivo quando `tpDesc=1` (Desconto em folha por consignado)

--- a/docs/EvtTSVTermino.md
+++ b/docs/EvtTSVTermino.md
@@ -64,3 +64,14 @@ A classe pode retornar: string XML, string JSON ou array com os dados
 </eSocial>
 
 ```
+
+## Alterações v_S_01_03_00 (NT S-1.3 nº 06/2026)
+
+### Campo `notAFT` (novo)
+- **Localização:** `infoTSVTermino/verbasResc/dmDev/notAFT`
+- **Tipo:** `TS_notAFT` — 9 caracteres alfanuméricos (`[A-Za-z0-9]{9}`)
+- **Obrigatoriedade:** Opcional
+- **Descrição:** Número da notificação do FGTS Digital. Só aplicável se mês/ano de `dtTerm` for igual ou posterior ao início do FGTS Digital.
+
+### Campos `indRRA` e `infoRRA` (adicionados ao `toNodeS130`)
+- A versão S130 do layout passa a suportar explicitamente `indRRA` e `infoRRA` dentro de `dmDev`, alinhando com a versão S1.2.0 do schema `evtTSVTermino.xsd`.

--- a/examples/Fake/v_S_01_03_00/Fake_s1200_EvtRemun.php
+++ b/examples/Fake/v_S_01_03_00/Fake_s1200_EvtRemun.php
@@ -2,7 +2,7 @@
 
 error_reporting(E_ALL);
 ini_set('display_errors', 'On');
-require_once '../../../bootstrap.php';
+require_once __DIR__ . '/../../../bootstrap.php';
 
 use NFePHP\Common\Certificate;
 use NFePHP\eSocial\Event;
@@ -47,7 +47,8 @@ $std->infomv->indmv = 1; //Obrigatório
 //empregatício com outra(s) empresa(s)
 $std->infomv->remunoutrempr[0] = new \stdClass(); //Obrigatório
 $std->infomv->remunoutrempr[0]->tpinsc = 1; //Obrigatório
-$std->infomv->remunoutrempr[0]->nrinsc = '12345678901234'; //Obrigatório
+// $std->infomv->remunoutrempr[0]->nrinsc = '12345678901234'; //Obrigatório
+$std->infomv->remunoutrempr[0]->nrinsc = 'ABCDEFGH000100'; //Obrigatório
 $std->infomv->remunoutrempr[0]->codcateg = 901; //Obrigatório
 $std->infomv->remunoutrempr[0]->vlrremunoe = 2345.09; //Obrigatório
 
@@ -82,6 +83,7 @@ $std->infointerm[0]->dia = 10; //Obrigatório
 $std->dmdev[0] = new \stdClass(); //Obrigatório
 $std->dmdev[0]->idedmdev = 'kjdkjdkjdkdj'; //Obrigatório
 $std->dmdev[0]->codcateg = 101; //Obrigatório
+$std->dmdev[0]->notaft = 'A1B2C3D4E'; //Opcional - Notificação FGTS Digital (9 chars alfanum)
 
 $std->dmdev[0]->indrra = 'S';
 //Indicativo de Rendimentos Recebidos Acumuladamente - RRA.
@@ -225,7 +227,7 @@ $std->dmdev[0]->infocomplcont->qtddiastrab = 14; //Obrigatório
 
 try {
     //carrega a classe responsavel por lidar com os certificados
-    $content = file_get_contents('expired_certificate.pfx');
+    $content = file_get_contents(__DIR__ . '/expired_certificate.pfx');
     $password = 'associacao';
     $certificate = Certificate::readPfx($content, $password);
 

--- a/examples/Fake/v_S_01_03_00/Fake_s2299_EvtDeslig.php
+++ b/examples/Fake/v_S_01_03_00/Fake_s2299_EvtDeslig.php
@@ -2,7 +2,7 @@
 
 error_reporting(E_ALL);
 ini_set('display_errors', 'On');
-require_once '../../../bootstrap.php';
+require_once __DIR__ . '/../../../bootstrap.php';
 
 use NFePHP\Common\Certificate;
 use NFePHP\eSocial\Event;
@@ -76,6 +76,7 @@ $std->verbasresc = new \stdClass(); //Opcional
 //Identificação de cada um dos demonstrativos de valores devidos ao trabalhador
 $std->verbasresc->dmdev[1] = new \stdClass();  //Obrigatório
 $std->verbasresc->dmdev[1]->idedmdev = 'akakakak737477382828282828282';  //Obrigatório
+$std->verbasresc->dmdev[1]->notaft = 'X1Y2Z3W4Q'; //Opcional - Notificação FGTS Digital (9 chars alfanum)
 
 //Verbas rescisórias relativas ao mês/ano da data do desligamento.
 $std->verbasresc->dmdev[1]->infoperapur = new \stdClass(); //Opcional
@@ -184,7 +185,7 @@ $std->consigfgts[0]->nrcontr = '123456789012345'; //Obrigatório
 
 try {
     //carrega a classe responsavel por lidar com os certificados
-    $content = file_get_contents('expired_certificate.pfx');
+    $content = file_get_contents(__DIR__ . '/expired_certificate.pfx');
     $password = 'associacao';
     $certificate = Certificate::readPfx($content, $password);
 

--- a/examples/Fake/v_S_01_03_00/Fake_s2399_EvtTSVTermino.php
+++ b/examples/Fake/v_S_01_03_00/Fake_s2399_EvtTSVTermino.php
@@ -2,7 +2,7 @@
 
 error_reporting(E_ALL);
 ini_set('display_errors', 'On');
-require_once '../../../bootstrap.php';
+require_once __DIR__ . '/../../../bootstrap.php';
 
 use NFePHP\Common\Certificate;
 use NFePHP\eSocial\Event;
@@ -48,6 +48,7 @@ $std->novocpf = "12345678901";
 $std->verbasresc = new \stdClass();
 $std->verbasresc->dmdev[1] = new \stdClass();
 $std->verbasresc->dmdev[1]->idedmdev = 'ksksksksksksksk';
+$std->verbasresc->dmdev[1]->notaft = 'B3C5D7E9F'; //Opcional - Notificação FGTS Digital (9 chars alfanum)
 
 $std->verbasresc->dmdev[1]->ideestablot[1] = new \stdClass();
 $std->verbasresc->dmdev[1]->ideestablot[1]->tpinsc = 1;
@@ -92,7 +93,7 @@ $std->remunaposterm->dtfimremun = '2023-01-22'; //Obrigatório
 
 try {
     //carrega a classe responsavel por lidar com os certificados
-    $content = file_get_contents('expired_certificate.pfx');
+    $content = file_get_contents(__DIR__ . '/expired_certificate.pfx');
     $password = 'associacao';
     $certificate = Certificate::readPfx($content, $password);
 

--- a/examples/Fake/v_S_01_03_00/Fake_s2410_evtCdBenIn.php
+++ b/examples/Fake/v_S_01_03_00/Fake_s2410_evtCdBenIn.php
@@ -52,6 +52,8 @@ $std->infopenmorte->tppenmorte = 1; //obrigatório
 $std->infopenmorte->instpenmorte = new \stdClass();
 $std->infopenmorte->instpenmorte->cpfinst = '12345678901'; //obrigatório
 $std->infopenmorte->instpenmorte->dtinst = '2020-12-12'; //obrigatório
+$std->infopenmorte->instpenmorte->tpdepinst = '01'; //opcional - Tipo de dependente do instituidor
+$std->infopenmorte->instpenmorte->descrdepinst = null; //opcional - Descrição do dependente
 
 //campo opcional
 $std->sucessaobenef = new \stdClass();

--- a/examples/Fake/v_S_01_03_00/Fake_s2416_evtCdBenAlt.php
+++ b/examples/Fake/v_S_01_03_00/Fake_s2416_evtCdBenAlt.php
@@ -2,7 +2,7 @@
 
 error_reporting(E_ALL);
 ini_set('display_errors', 'On');
-require_once '../../../bootstrap.php';
+require_once __DIR__ . '/../../../bootstrap.php';
 
 use NFePHP\Common\Certificate;
 use NFePHP\eSocial\Event;
@@ -42,6 +42,10 @@ $std->indsuspensao = "N";
 //opcional
 $std->infopenmorte = new \stdClass();
 $std->infopenmorte->tppenmorte = 1; //obrigatorio
+//opcional - grupo instPenMorte (S.1.3.0: tpDepInst obrig se grupo informado, sem cpfInst/dtInst)
+$std->infopenmorte->instpenmorte = new \stdClass();
+$std->infopenmorte->instpenmorte->tpdepinst = '01'; //obrigatório dentro do grupo
+$std->infopenmorte->instpenmorte->descrdepinst = null; //opcional
 //opcional
 $std->suspensao = new \stdClass();
 $std->suspensao->mtvsuspensao = '01';
@@ -50,7 +54,7 @@ $std->suspensao->dscsuspensao = 'bla bla bla bla';
 
 try {
     //carrega a classe responsavel por lidar com os certificados
-    $content = file_get_contents('expired_certificate.pfx');
+    $content = file_get_contents(__DIR__ . '/expired_certificate.pfx');
     $password = 'associacao';
     $certificate = Certificate::readPfx($content, $password);
 

--- a/examples/Fake/v_S_01_03_00/Fake_s2500_EvtProcTrab.php
+++ b/examples/Fake/v_S_01_03_00/Fake_s2500_EvtProcTrab.php
@@ -2,7 +2,7 @@
 
 error_reporting(E_ALL);
 ini_set('display_errors', 'On');
-require_once '../../../bootstrap.php';
+require_once __DIR__ . '/../../../bootstrap.php';
 
 use NFePHP\Common\Certificate;
 use NFePHP\eSocial\Event;
@@ -46,6 +46,8 @@ $std->infoprocjud->dtsent = '2022-12-03';
 $std->infoprocjud->ufvara = 'SP';
 $std->infoprocjud->codmunic = '3504808';
 $std->infoprocjud->idvara = '12';
+// infoPatPrec: obrigatório e exclusivo se origem = 3 (Justiça Comum)
+$std->infoprocjud->infopatprec = null; //Opcional (obrigatório se $std->origem = 3)
 
 $std->infocccp = new \stdClass();
 $std->infocccp->dtccp = '2022-12-03';
@@ -156,7 +158,7 @@ $std->infocontr[0]->ideestab->infovlr->ideperiodo[0]->basemudcateg->vrbccprev = 
 
 try {
     //carrega a classe responsavel por lidar com os certificados
-    $content = file_get_contents('expired_certificate.pfx');
+    $content = file_get_contents(__DIR__ . '/expired_certificate.pfx');
     $password = 'associacao';
     $certificate = Certificate::readPfx($content, $password);
 

--- a/jsonSchemes/v_S_01_03_00/evtAdmissao.schema
+++ b/jsonSchemes/v_S_01_03_00/evtAdmissao.schema
@@ -386,7 +386,7 @@
                         "cnpjsindcategprof": {
                             "required": true,
                             "type": "string",
-                            "pattern": "^[0-9]{14}$"
+                            "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                         },
                         "dtopcfgts": {
                             "required": false,
@@ -422,7 +422,7 @@
                                         "nrinsc": {
                                             "required": true,
                                             "type": "string",
-                                            "pattern": "^([0-9]{11}|[0-9]{14})$"
+                                            "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                                         }
                                     }
                                 },
@@ -457,7 +457,7 @@
                                 "cnpjentqual": {
                                     "required": false,
                                     "type": ["string","null"],
-                                    "pattern": "^[0-9]{14}$"
+                                    "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                                 },
                                 "tpinsc": {
                                     "required": false,
@@ -468,12 +468,12 @@
                                 "nrinsc": {
                                     "required": false,
                                     "type": ["string","null"],
-                                    "pattern": "^([0-9]{11}|[0-9]{14})$"
+                                    "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                                 },
                                 "cnpjprat": {
                                     "required": false,
                                     "type": ["string","null"],
-                                    "pattern": "^[0-9]{14}$"
+                                    "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                                 }
                             }
                         }
@@ -617,7 +617,7 @@
                                 "nrinsc": {
                                     "required": true,
                                     "type": "string",
-                                    "pattern": "^([0-9]{11}|[0-9]{14})$"
+                                    "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                                 },
                                 "desccomp": {
                                       "required": false,
@@ -767,7 +767,7 @@
                         "nrinsc": {
                             "required": true,
                             "type": "string",
-                            "pattern": "^([0-9]{8}|[0-9]{11}|[0-9]{12}|[0-9]{14})$"
+                            "pattern": "^([A-Z0-9]{8}|[0-9]{11}|[0-9]{12}|[A-Z0-9]{12}[0-9]{2})$"
                         },
                         "matricant": {
                               "required": false,

--- a/jsonSchemes/v_S_01_03_00/evtAfastTemp.schema
+++ b/jsonSchemes/v_S_01_03_00/evtAfastTemp.schema
@@ -93,7 +93,7 @@
                         "cnpjcess": {
                             "required": true,
                             "type": "string",
-                            "pattern": "^[0-9]{14}$"
+                            "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                         },
                         "infonus": {
                             "required": true,
@@ -110,7 +110,7 @@
                         "cnpjsind": {
                             "required": true,
                             "type": "string",
-                            "pattern": "^[0-9]{14}$"
+                            "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                         },
                         "infonusremun": {
                             "required": true,
@@ -127,7 +127,7 @@
                         "cnpjmandelet": {
                             "required": true,
                             "type": "string",
-                            "pattern": "^[0-9]{14}$"
+                            "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                         },
                         "indremuncargo": {
                             "required": false,

--- a/jsonSchemes/v_S_01_03_00/evtAltContratual.schema
+++ b/jsonSchemes/v_S_01_03_00/evtAltContratual.schema
@@ -77,7 +77,7 @@
                 "cnpjsindcategprof": {
                     "required": true,
                     "type": "string",
-                    "pattern": "^[0-9]{8,14}$"
+                    "pattern": "^([A-Z0-9]{8}|[A-Z0-9]{12}[0-9]{2})$"
                 },
                 "trabtemporario": {
                     "required": false,
@@ -104,7 +104,7 @@
                         "cnpjentqual": {
                             "required": false,
                             "type": ["string","null"],
-                            "pattern": "^[0-9]{14}$"
+                            "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                         },
                         "tpinsc": {
                             "required": false,
@@ -115,12 +115,12 @@
                         "nrinsc": {
                             "required": false,
                             "type": ["string","null"],
-                            "pattern": "^[0-9]{8,14}$"
+                            "pattern": "^([A-Z0-9]{8}|[A-Z0-9]{12}[0-9]{2})$"
                         },
                         "cnpjprat": {
                             "required": false,
                             "type": ["string","null"],
-                            "pattern": "^[0-9]{14}$"
+                            "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                         }
                     }
                 }
@@ -227,7 +227,7 @@
                         "nrinsc": {
                             "required": true,
                             "type": "string",
-                            "pattern": "^[0-9]{11,14}$"
+                            "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                         },
                         "desccomp": {
                               "required": false,

--- a/jsonSchemes/v_S_01_03_00/evtBenPrRP.schema
+++ b/jsonSchemes/v_S_01_03_00/evtBenPrRP.schema
@@ -119,7 +119,7 @@
                                         "nrinsc": {
                                             "required": true,
                                             "type": "string",
-                                            "pattern": "^([0-9]{11}|[0-9]{14})$"
+                                            "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                                         }
                                     }
                                 }
@@ -147,7 +147,7 @@
                                         "nrinsc": {
                                             "required": true,
                                             "type": "string",
-                                            "pattern": "^[0-9]{14}$"
+                                            "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                                         },
                                         "itensremun": {
                                             "required": true,
@@ -257,7 +257,7 @@
                                                     "nrinsc": {
                                                         "required": true,
                                                         "type": "string",
-                                                        "pattern": "^[0-9]{14}$"
+                                                        "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                                                     },
                                                     "itensremun": {
                                                         "required": true,

--- a/jsonSchemes/v_S_01_03_00/evtCAT.schema
+++ b/jsonSchemes/v_S_01_03_00/evtCAT.schema
@@ -185,7 +185,7 @@
                 "nrinsc": {
                     "required": true,
                     "type": "string",
-                    "pattern": "^[0-9]{8,14}$"
+                    "pattern": "^([A-Z0-9]{8}|[A-Z0-9]{12}[0-9]{2})$"
                 }
             }
         },

--- a/jsonSchemes/v_S_01_03_00/evtCdBenAlt.schema
+++ b/jsonSchemes/v_S_01_03_00/evtCdBenAlt.schema
@@ -64,6 +64,22 @@
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 2
+                },
+                "instpenmorte": {
+                    "required": false,
+                    "type": ["object","null"],
+                    "properties": {
+                        "tpdepinst": {
+                            "required": true,
+                            "type": "string",
+                            "maxLength": 2
+                        },
+                        "descrdepinst": {
+                            "required": false,
+                            "type": ["string","null"],
+                            "maxLength": 100
+                        }
+                    }
                 }
             }
         },

--- a/jsonSchemes/v_S_01_03_00/evtCdBenIn.schema
+++ b/jsonSchemes/v_S_01_03_00/evtCdBenIn.schema
@@ -32,7 +32,7 @@
         "cnpjorigem": {
             "required": false,
             "type": ["string","null"],
-            "pattern": "^[0-9]{14}$"
+            "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
         },
         "cadini": {
             "required": true,
@@ -104,6 +104,16 @@
                             "required": true,
                             "type": "string",
                             "$ref": "#/definitions/data"
+                        },
+                        "tpdepinst": {
+                            "required": false,
+                            "type": ["string","null"],
+                            "maxLength": 2
+                        },
+                        "descrdepinst": {
+                            "required": false,
+                            "type": ["string","null"],
+                            "maxLength": 100
                         }
                     }
                 }
@@ -116,7 +126,7 @@
                 "cnpjorgaoant": {
                     "required": true,
                     "type": "string",
-                    "pattern": "^[0-9]{14}$"
+                    "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                 },
                 "nrbeneficioant": {
                     "required": true,

--- a/jsonSchemes/v_S_01_03_00/evtCdBenTerm.schema
+++ b/jsonSchemes/v_S_01_03_00/evtCdBenTerm.schema
@@ -42,7 +42,7 @@
         "cnpjorgaosuc": {
             "required": false,
             "type": ["string","null"],
-            "pattern": "^[0-9]{14}$"
+            "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
         },
         "novocpf": {
             "required": false,

--- a/jsonSchemes/v_S_01_03_00/evtCessao.schema
+++ b/jsonSchemes/v_S_01_03_00/evtCessao.schema
@@ -42,7 +42,7 @@
                 "cnpjcess": {
                     "required": true,
                     "type": "string",
-                    "pattern": "^[0-9]{14}$"
+                    "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                 },
                 "respremun": {
                     "required": true,

--- a/jsonSchemes/v_S_01_03_00/evtComProd.schema
+++ b/jsonSchemes/v_S_01_03_00/evtComProd.schema
@@ -31,7 +31,7 @@
                 "nrinscestabrural": {
                     "required": true,
                     "type": "string",
-                    "pattern": "^[0-9]{14}$"
+                    "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                 },
                 "tpcomerc": {
                     "required": true,
@@ -66,7 +66,7 @@
                                         "nrinsc": {
                                             "required": true,
                                             "type": "string",
-                                            "pattern": "^([0-9]{11}|[0-9]{14})$"
+                                            "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                                         },
                                         "vrcomerc": {
                                             "required": true,

--- a/jsonSchemes/v_S_01_03_00/evtContProc.schema
+++ b/jsonSchemes/v_S_01_03_00/evtContProc.schema
@@ -193,7 +193,7 @@
                                                             "nrinsc": {
                                                                 "required": true,
                                                                 "type": "string",
-                                                                "pattern": "^[0-9]{11,14}$"
+                                                                "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                                                             },
                                                             "vlradv": {
                                                                 "required": false,

--- a/jsonSchemes/v_S_01_03_00/evtContratAvNP.schema
+++ b/jsonSchemes/v_S_01_03_00/evtContratAvNP.schema
@@ -46,7 +46,7 @@
                     "nrinsc": {
                         "required": true,
                         "type": "string",
-                        "pattern": "^[0-9]{12}|[0-9]{14}$"
+                        "pattern": "^([0-9]{12}|[A-Z0-9]{12}[0-9]{2})$"
                     },
                     "codlotacao": {
                         "required": true,

--- a/jsonSchemes/v_S_01_03_00/evtDeslig.schema
+++ b/jsonSchemes/v_S_01_03_00/evtDeslig.schema
@@ -125,7 +125,7 @@
                 "nrinsc": {
                     "required": true,
                     "type": "string",
-                    "pattern": "^[0-9]{11}|[0-9]{14}$"
+                    "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                 }
             }
         },
@@ -178,6 +178,11 @@
                                 "type": ["string","null"],
                                 "pattern": "^(S)$"
                             },
+                            "notaft": {
+                                "required": false,
+                                "type": ["string","null"],
+                                "pattern": "^([A-Za-z0-9]{9})?$"
+                            },
                             "infoperapur": {
                                 "required": false,
                                 "type": ["object","null"],
@@ -198,7 +203,7 @@
                                                 "nrinsc": {
                                                     "required": true,
                                                     "type": "string",
-                                                    "pattern": "^[0-9]{12}|[0-9]{14}$"
+                                                    "pattern": "^([0-9]{12}|[A-Z0-9]{12}[0-9]{2})$"
                                                 },
                                                 "codlotacao": {
                                                     "required": true,
@@ -360,7 +365,7 @@
                                                                         "nrinsc": {
                                                                             "required": true,
                                                                             "type": "string",
-                                                                            "pattern": "^[0-9]{8,14}"
+                                                                            "pattern": "^([A-Z0-9]{8}|[A-Z0-9]{12}[0-9]{2})"
                                                                         },
                                                                         "codlotacao": {
                                                                             "required": true,
@@ -498,7 +503,7 @@
                                     "nrinsc": {
                                         "required": true,
                                         "type": "string",
-                                        "pattern": "^[0-9]{8,14}$"
+                                        "pattern": "^([A-Z0-9]{8}|[A-Z0-9]{12}[0-9]{2})$"
                                     },
                                     "codcateg": {
                                         "required": true,

--- a/jsonSchemes/v_S_01_03_00/evtExpRisco.schema
+++ b/jsonSchemes/v_S_01_03_00/evtExpRisco.schema
@@ -68,7 +68,7 @@
                 "nrinsc": {
                     "required": true,
                     "type": "string",
-                    "pattern": "^[0-9]{8,14}$"
+                    "pattern": "^([A-Z0-9]{8}|[A-Z0-9]{12}[0-9]{2})$"
                 }
             }
         },

--- a/jsonSchemes/v_S_01_03_00/evtInfoEmpregador.schema
+++ b/jsonSchemes/v_S_01_03_00/evtInfoEmpregador.schema
@@ -76,7 +76,7 @@
                 "cnpjefr": {
                     "required": false,
                     "type": ["string","null"],
-                    "pattern": "^[0-9]{14}$"
+                    "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                 },
                 "dttrans11096": {
                     "required": false,

--- a/jsonSchemes/v_S_01_03_00/evtPgtos.schema
+++ b/jsonSchemes/v_S_01_03_00/evtPgtos.schema
@@ -303,7 +303,7 @@
                                             "cnpjentidpc": {
                                                 "required": true,
                                                 "type": "string",
-                                                "pattern": "^[0-9]{14}$"
+                                                "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                                             },
                                             "vlrdedpc": {
                                                 "required": false,
@@ -396,7 +396,7 @@
                                                                     "cnpjentidpc": {
                                                                         "required": false,
                                                                         "type": ["string","null"],
-                                                                        "pattern": "^[0-9]{14}$"
+                                                                        "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                                                                     },
                                                                     "vlrpatrocfunp": {
                                                                         "required": false,
@@ -445,7 +445,7 @@
                                 "cnpjoper": {
                                     "required": true,
                                     "type": "string",
-                                    "pattern": "^[0-9]{14}$"
+                                    "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                                 },
                                 "regans": {
                                     "required": false,
@@ -495,7 +495,7 @@
                                 "cnpjoper": {
                                     "required": true,
                                     "type": "string",
-                                    "pattern": "^[0-9]{14}$"
+                                    "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                                 },
                                 "regans": {
                                     "required": false,
@@ -518,7 +518,7 @@
                                             "nrinsc": {
                                                 "required": true,
                                                 "type": "string",
-                                                "pattern": "^[0-9]{11,14}$"
+                                                "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                                             },
                                             "vlrreemb": {
                                                 "required": false,
@@ -560,7 +560,7 @@
                                                         "nrinsc": {
                                                             "required": true,
                                                             "type": "string",
-                                                            "pattern": "^[0-9]{11,14}$"
+                                                            "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                                                         },
                                                         "vlrreemb": {
                                                             "required": false,

--- a/jsonSchemes/v_S_01_03_00/evtProcTrab.schema
+++ b/jsonSchemes/v_S_01_03_00/evtProcTrab.schema
@@ -32,7 +32,7 @@
                 "nrinsc": {
                     "required": true,
                     "type": "string",
-                    "pattern": "^[0-9]{11,14}$"
+                    "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                 }
             }
         },
@@ -76,6 +76,11 @@
                     "required": true,
                     "type": "string",
                     "pattern": "^[0-9]{1,4}$"
+                },
+                "infopatprec": {
+                    "required": false,
+                    "type": ["number","null"],
+                    "minimum": 0
                 }
             }
         },
@@ -97,7 +102,7 @@
                 "cnpjccp": {
                     "required": false,
                     "type": ["string","null"],
-                    "pattern": "^[0-9]{14}$"
+                    "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                 }
             }
         },
@@ -308,7 +313,7 @@
                                             "nrinsc": {
                                                 "required": true,
                                                 "type": "string",
-                                                "pattern": "^[0-9]{11,14}$"
+                                                "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                                             },
                                             "matricant": {
                                                 "required": false,
@@ -443,7 +448,7 @@
                             "nrinsc": {
                                 "required": true,
                                 "type": "string",
-                                "pattern": "^[0-9]{12,14}$"
+                                "pattern": "^([0-9]{12}|[A-Z0-9]{12}[0-9]{2})$"
                             },
                             "infovlr": {
                                 "required": true,

--- a/jsonSchemes/v_S_01_03_00/evtRemun.schema
+++ b/jsonSchemes/v_S_01_03_00/evtRemun.schema
@@ -68,7 +68,7 @@
                             "nrinsc": {
                                 "required": true,
                                 "type": "string",
-                                "pattern": "^[0-9]{11,14}"
+                                "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})"
                             },
                             "codcateg": {
                                 "required": true,
@@ -113,7 +113,7 @@
                         "nrinsc": {
                             "required": true,
                             "type": "string",
-                            "pattern": "^[0-9]{11,14}$"
+                            "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                         },
                         "matricant": {
                             "required": false,
@@ -201,6 +201,11 @@
                         "type": ["string","null"],
                         "pattern": "^(S)$"
                     },
+                    "notaft": {
+                        "required": false,
+                        "type": ["string","null"],
+                        "pattern": "^([A-Za-z0-9]{9})?$"
+                    },
                     "inforra": {
                         "required": false,
                         "type": [
@@ -269,7 +274,7 @@
                                                 "nrinsc": {
                                                     "required": true,
                                                     "type": "string",
-                                                    "pattern": "^[0-9]{11,14}$"
+                                                    "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                                                 },
                                                 "vlradv": {
                                                     "required": true,
@@ -451,7 +456,7 @@
                                                                 "nrinsc": {
                                                                     "required": true,
                                                                     "type": "string",
-                                                                    "pattern": "^[0-9]{11,14}"
+                                                                    "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})"
                                                                 },
                                                                 "codlotacao": {
                                                                     "required": true,
@@ -485,7 +490,7 @@
                                 "nrinsc": {
                                     "required": true,
                                     "type": "string",
-                                    "pattern": "^[0-9]{8,14}"
+                                    "pattern": "^([A-Z0-9]{8}|[A-Z0-9]{12}[0-9]{2})"
                                 },
                                 "codlotacao": {
                                     "required": true,
@@ -749,7 +754,7 @@
                                                         "nrinsc": {
                                                             "required": true,
                                                             "type": "string",
-                                                            "pattern": "^[0-9]{8,14}"
+                                                            "pattern": "^([A-Z0-9]{8}|[A-Z0-9]{12}[0-9]{2})"
                                                         },
                                                         "codlotacao": {
                                                             "required": true,

--- a/jsonSchemes/v_S_01_03_00/evtRmnRPPS.schema
+++ b/jsonSchemes/v_S_01_03_00/evtRmnRPPS.schema
@@ -69,7 +69,7 @@
                         "cnpjorgaoant": {
                             "required": true,
                             "type": "string",
-                            "pattern": "^[0-9]{14}$"
+                            "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                         },
                         "matricant": {
                             "required": false,
@@ -190,7 +190,7 @@
                                                 "nrinsc": {
                                                     "required": true,
                                                     "type": "string",
-                                                    "pattern": "^[0-9]{11,14}$"
+                                                    "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                                                 },
                                                 "vlradv": {
                                                     "required": true,
@@ -225,7 +225,7 @@
                                         "nrinsc": {
                                             "required": true,
                                             "type": "string",
-                                            "pattern": "^[0-9]{14}$"
+                                            "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                                         },
                                         "remunperapur": {
                                             "required": true,
@@ -369,7 +369,7 @@
                                                     "nrinsc": {
                                                         "required": true,
                                                         "type": "string",
-                                                        "pattern": "^[0-9]{14}$"
+                                                        "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                                                     },
                                                     "remumperant": {
                                                         "required": true,

--- a/jsonSchemes/v_S_01_03_00/evtTSVAltContr.schema
+++ b/jsonSchemes/v_S_01_03_00/evtTSVAltContr.schema
@@ -183,7 +183,7 @@
                         "cnpjinstensino": {
                             "required": true,
                             "type": "string",
-                            "pattern": "^[0-9]{14}$"
+                            "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                         },
                         "nmrazao": {
                             "required": true,
@@ -229,7 +229,7 @@
                         "cnpjagntinteg": {
                             "required": true,
                             "type": "string",
-                            "pattern": "^[0-9]{14}$"
+                            "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                         }
                     }
                 },
@@ -259,7 +259,7 @@
                 "nrinsc": {
                     "required": true,
                     "type": "string",
-                    "pattern": "^[0-9]{11,14}$"
+                    "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                 },
                 "desccomp": {
                     "required": false,

--- a/jsonSchemes/v_S_01_03_00/evtTSVInicio.schema
+++ b/jsonSchemes/v_S_01_03_00/evtTSVInicio.schema
@@ -408,7 +408,7 @@
                 "nrinsc": {
                     "required": false,
                     "type": ["string","null"],
-                    "pattern": "^[0-9]{11,14}$"
+                    "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                 },
                 "dtadmorig": {
                     "required": false,
@@ -447,7 +447,7 @@
                 "cnpjcednt": {
                     "required": true,
                     "type": "string",
-                    "pattern": "^[0-9]{14}$"
+                    "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                 },
                 "matricced": {
                     "required": true,
@@ -486,7 +486,7 @@
                 "cnpjorig": {
                     "required": true,
                     "type": "string",
-                    "pattern": "^[0-9]{14}$"
+                    "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                 },
                 "matricorig": {
                     "required": true,
@@ -557,7 +557,7 @@
                         "cnpjinstensino": {
                             "required": false,
                             "type": ["string","null"],
-                            "pattern": "^[0-9]{14}$"
+                            "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                         },
                         "nmrazao": {
                             "required": false,
@@ -603,7 +603,7 @@
                 "cnpjagntinteg": {
                     "required": false,
                     "type": ["string","null"],
-                    "pattern": "^[0-9]{14}$"
+                    "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                 },
                 "cpfsupervisor": {
                     "required": false,
@@ -625,7 +625,7 @@
                 "nrinsc": {
                     "required": true,
                     "type": "string",
-                    "pattern": "^[0-9]{11,14}$"
+                    "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                 },
                 "desccomp": {
                     "required": false,

--- a/jsonSchemes/v_S_01_03_00/evtTSVTermino.schema
+++ b/jsonSchemes/v_S_01_03_00/evtTSVTermino.schema
@@ -98,6 +98,11 @@
                                 "type": ["string","null"],
                                 "pattern": "^(S)$"
                             },
+                            "notaft": {
+                                "required": false,
+                                "type": ["string","null"],
+                                "pattern": "^([A-Za-z0-9]{9})?$"
+                            },
                             "ideestablot": {
                                 "required": true,
                                 "type": "array",
@@ -115,7 +120,7 @@
                                         "nrinsc": {
                                             "required": true,
                                             "type": "string",
-                                            "pattern": "^[0-9]{8,14}$"
+                                            "pattern": "^([A-Z0-9]{8}|[A-Z0-9]{12}[0-9]{2})$"
                                         },
                                         "codlotacao": {
                                             "required": true,
@@ -236,7 +241,7 @@
                                     "nrinsc": {
                                         "required": true,
                                         "type": "string",
-                                        "pattern": "^[0-9]{8,14}$"
+                                        "pattern": "^([A-Z0-9]{8}|[A-Z0-9]{12}[0-9]{2})$"
                                     },
                                     "codcateg": {
                                         "required": true,

--- a/jsonSchemes/v_S_01_03_00/evtTabEstab.schema
+++ b/jsonSchemes/v_S_01_03_00/evtTabEstab.schema
@@ -17,7 +17,7 @@
         "nrinsc": {
             "required": true,
             "type": "string",
-            "pattern": "^[0-9]{12}|[0-9]{14}$"
+            "pattern": "^([0-9]{12}|[A-Z0-9]{12}[0-9]{2})$"
         },
         "inivalid": {
             "required": true,
@@ -46,7 +46,7 @@
                 "cnpjresp": {
                     "required": false,
                     "type": ["string","null"],
-                    "pattern": "^[0-9]{14}"
+                    "pattern": "^[A-Z0-9]{12}[0-9]{2}"
                 },
                 "aliqgilrat": {
                     "required": false,
@@ -160,7 +160,7 @@
                                             "nrinsc": {
                                                 "required": true,
                                                 "type": "string",
-                                                "pattern": "^[0-9]{14}$"
+                                                "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                                             }
                                         }
                                     }

--- a/jsonSchemes/v_S_01_03_00/evtTabLotacao.schema
+++ b/jsonSchemes/v_S_01_03_00/evtTabLotacao.schema
@@ -46,7 +46,7 @@
                 "nrinsc": {
                     "required": false,
                     "type": ["string","null"],
-                    "pattern": "^[0-9]{11}|[0-9]{12}|[0-9]{14}}$"
+                    "pattern": "^([0-9]{11}|[0-9]{12}|[A-Z0-9]{12}[0-9]{2})$"
                 },
                 "fpas": {
                     "required": true,
@@ -102,7 +102,7 @@
                         "nrinsccontrat": {
                             "required": true,
                             "type": "string",
-                            "pattern": "^[0-9]{11,14}$"
+                            "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                         },
                         "tpinscprop": {
                             "required": false,
@@ -113,7 +113,7 @@
                         "nrinscprop": {
                             "required": false,
                             "type": ["string","null"],
-                            "pattern": "^[0-9]{11,14}$"
+                            "pattern": "^([0-9]{11}|[A-Z0-9]{12}[0-9]{2})$"
                         }
                     }
                 },

--- a/jsonSchemes/v_S_01_03_00/evtToxic.schema
+++ b/jsonSchemes/v_S_01_03_00/evtToxic.schema
@@ -48,7 +48,7 @@
                 "cnpjlab": {
                     "required": true,
                     "type": ["string"],
-                    "pattern": "^[0-9]{14}$"
+                    "pattern": "^[A-Z0-9]{12}[0-9]{2}$"
                 },
                 "codseqexame": {
                     "required": true,

--- a/schemes/v_S_01_03_00/evtAdmPrelim.xsd
+++ b/schemes/v_S_01_03_00/evtAdmPrelim.xsd
@@ -46,7 +46,7 @@
                                         <xs:element name="dtAdm" type="xs:date">
                                             <xs:annotation>
                                                 <xs:documentation>Preencher com a data de admissão do trabalhador (ou data de início, no caso de Trabalhador Sem Vínculo de Emprego/Estatutário - TSVE).</xs:documentation>
-                                                <xs:documentation>Validação: Deve ser posterior à data de nascimento do trabalhador, igual ou posterior à data de início da obrigatoriedade dos eventos não periódicos para o empregador e igual ou anterior ao ano do óbito, se existente.</xs:documentation>
+                                                <xs:documentation>Validação: Deve ser posterior à data de nascimento do trabalhador, igual ou posterior à data de início da obrigatoriedade dos eventos não periódicos para o empregador e igual ou anterior à data do óbito, se existente (se não for possível obter a data do óbito, deve ser igual ou anterior ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta).</xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
                                         <xs:element name="matricula" type="TS_codigo_esocial">
@@ -73,7 +73,7 @@
                                             <xs:annotation>
                                                 <xs:documentation>Informações referentes ao registro e à CTPS Digital</xs:documentation>
                                                 <xs:documentation>DESCRICAO_COMPLETA:Informações referentes ao registro eletrônico de empregados e à Carteira de Trabalho e Previdência Digital - CTPS Digital.</xs:documentation>
-                                                <xs:documentation>CONDICAO_GRUPO: OC (se {codCateg}(2190_infoRegPrelim_codCateg) for relativo a "Empregado" ou "Agente Público"); N (nos demais casos)</xs:documentation>
+                                                <xs:documentation>CONDICAO_GRUPO: O (se {codCateg}(2190_infoRegPrelim_codCateg) for relativo a "Empregado" ou "Agente Público" e se {dtAdm}(../dtAdm) >= [2026-01-02]); OC (se {codCateg}(2190_infoRegPrelim_codCateg) for relativo a "Empregado" ou "Agente Público" e se {dtAdm}(../dtAdm) &lt; [2026-01-02]); N (nos demais casos)</xs:documentation>
                                             </xs:annotation>
                                             <xs:complexType>
                                                 <xs:sequence>

--- a/schemes/v_S_01_03_00/evtAdmissao.xsd
+++ b/schemes/v_S_01_03_00/evtAdmissao.xsd
@@ -225,7 +225,7 @@
                                                                             <xs:documentation>Preencher com a data de admissão do trabalhador.</xs:documentation>
                                                                             <xs:documentation>No caso de transferência do empregado ou de mudança de CPF, preencher com a data inicial do vínculo no primeiro empregador (data de início do vínculo).</xs:documentation>
                                                                             <xs:documentation>Validação: Devem ser observadas as seguintes regras:</xs:documentation>
-                                                                            <xs:documentation>a) Deve ser posterior à data de nascimento do trabalhador e igual ou anterior ao ano do óbito, se existente;</xs:documentation>
+                                                                            <xs:documentation>a) Deve ser posterior à data de nascimento do trabalhador e igual ou anterior à data do óbito, se existente (se não for possível obter a data do óbito, deve ser igual ou anterior ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta);</xs:documentation>
                                                                             <xs:documentation>b) Se {cadIni}(2200_vinculo_cadIni) = [S], deve ser anterior à data de início da obrigatoriedade dos eventos não periódicos para o empregador no eSocial;</xs:documentation>
                                                                             <xs:documentation>c) Se {cadIni}(2200_vinculo_cadIni) = [N] e {tpAdmissao}(2200_vinculo_infoRegimeTrab_infoCeletista_tpAdmissao) = [1], deve ser igual ou posterior à data de início da obrigatoriedade dos eventos não periódicos para o empregador no eSocial.</xs:documentation>
                                                                         </xs:annotation>
@@ -312,8 +312,8 @@
                                                                     <xs:element name="cnpjSindCategProf" type="TS_cnpjSindCategProf" />
                                                                     <xs:element name="matAnotJud" type="TS_codigo_esocial" minOccurs="0">
                                                                         <xs:annotation>
-                                                                            <xs:documentation>Matrícula informada no evento S-8200.</xs:documentation>
-                                                                            <xs:documentation>Validação: Deve corresponder à matrícula cadastrada no evento S-8200 para o CPF informado em {cpfTrab}(2200_trabalhador_cpfTrab).</xs:documentation>
+                                                                            <xs:documentation>Matrícula informada no evento S-2500 (com {indContr}(2500_ideTrab_infoContr_indContr) em S-2500 = [N]) ou S-8200.</xs:documentation>
+                                                                            <xs:documentation>Validação: Deve corresponder à matrícula cadastrada no evento S-2500 (com {indContr}(2500_ideTrab_infoContr_indContr) em S-2500 = [N]) ou S-8200 para o CPF informado em {cpfTrab}(2200_trabalhador_cpfTrab).</xs:documentation>
                                                                         </xs:annotation>
                                                                     </xs:element>
                                                                     <xs:element name="FGTS" minOccurs="0">
@@ -484,7 +484,7 @@
                                                                         <xs:annotation>
                                                                             <xs:documentation>Data da entrada em exercício pelo servidor.</xs:documentation>
                                                                             <xs:documentation>Validação: Devem ser observadas as seguintes regras:</xs:documentation>
-                                                                            <xs:documentation>a) Deve ser posterior à data de nascimento do trabalhador;</xs:documentation>
+                                                                            <xs:documentation>a) Deve ser posterior à data de nascimento do trabalhador e igual ou anterior à data do óbito, se existente (se não for possível obter a data do óbito, deve ser igual ou anterior ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta);</xs:documentation>
                                                                             <xs:documentation>b) Se {cadIni}(2200_vinculo_cadIni) = [S], deve ser anterior à data de início da obrigatoriedade dos eventos não periódicos para o empregador/ente público no eSocial;</xs:documentation>
                                                                             <xs:documentation>c) Se {cadIni}(2200_vinculo_cadIni) = [N] e {tpProv}(2200_vinculo_infoRegimeTrab_infoEstatutario_tpProv) for diferente de [5, 8, 10], deve ser igual ou posterior à data de início da obrigatoriedade dos eventos não periódicos para o empregador/ente público no eSocial.</xs:documentation>
                                                                         </xs:annotation>
@@ -694,13 +694,13 @@
                                                             <xs:annotation>
                                                                 <xs:documentation>Informar o número de inscrição do empregador anterior, de acordo com o tipo de inscrição indicado no campo {sucessaoVinc/tpInsc}(./tpInsc).</xs:documentation>
                                                                 <xs:documentation>Validação: Deve ser um número de inscrição válido e diferente da inscrição do declarante, considerando as particularidades aplicadas à informação de CNPJ de órgão público em S-1000.</xs:documentation>
-                                                                <xs:documentation>Se {sucessaoVinc/tpInsc}(./tpInsc) = [1], deve possuir 14 (catorze) algarismos e ser diferente do CNPJ base do empregador (exceto se {ideEmpregador/nrInsc}(2200_ideEmpregador_nrInsc) tiver 14 (catorze) algarismos) e dos estabelecimentos informados através do evento S-1005.</xs:documentation>
+                                                                <xs:documentation>Se {sucessaoVinc/tpInsc}(./tpInsc) = [1], deve possuir 14 (catorze) algarismos e ser diferente do CNPJ base do empregador (exceto se {ideEmpregador/nrInsc}(2200_ideEmpregador_nrInsc) tiver 14 (catorze) algarismos). Também deve ser diferente dos estabelecimentos informados através do evento S-1005, exceto se a natureza jurídica do declarante for Administração Pública (grupo [1]).</xs:documentation>
                                                                 <xs:documentation>Se {sucessaoVinc/tpInsc}(./tpInsc) = [2], deve possuir 11 (onze) algarismos.</xs:documentation>
                                                                 <xs:documentation>Se {sucessaoVinc/tpInsc}(./tpInsc) = [5], deve possuir somente algarismos.</xs:documentation>
                                                                 <xs:documentation>Se {sucessaoVinc/tpInsc}(./tpInsc) = [6], deve possuir 12 (doze) algarismos.</xs:documentation>
                                                             </xs:annotation>
                                                             <xs:restriction base="xs:string">
-                                                                <xs:pattern value="\d{8,14}" />
+                                                                <xs:pattern value="\d{8,14}|[A-Z0-9]{12}\d{2}" />
                                                             </xs:restriction>
                                                         </xs:simpleType>
                                                     </xs:element>
@@ -714,7 +714,7 @@
                                                         <xs:annotation>
                                                             <xs:documentation>Preencher com a data da transferência do empregado para o empregador declarante.</xs:documentation>
                                                             <xs:documentation>Validação: Devem ser observadas as seguintes regras:</xs:documentation>
-                                                            <xs:documentation>a) Deve ser posterior à data de admissão do trabalhador e igual ou anterior ao ano do óbito, se existente;</xs:documentation>
+                                                            <xs:documentation>a) Deve ser posterior à data de admissão do trabalhador e igual ou anterior à data do óbito, se existente (se não for possível obter a data do óbito, deve ser igual ou anterior ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta);</xs:documentation>
                                                             <xs:documentation>b) Se {cadIni}(2200_vinculo_cadIni) = [S], deve ser anterior à data de início da obrigatoriedade dos eventos não periódicos para o empregador;</xs:documentation>
                                                             <xs:documentation>c) Se {cadIni}(2200_vinculo_cadIni) = [N], deve ser igual ou posterior à data de início da obrigatoriedade dos eventos não periódicos para o empregador.</xs:documentation>
                                                         </xs:annotation>
@@ -811,8 +811,9 @@
                                                             <xs:documentation>Preencher com a data de desligamento do vínculo (último dia trabalhado).</xs:documentation>
                                                             <xs:documentation>Validação: Devem ser observadas as seguintes regras:</xs:documentation>
                                                             <xs:documentation>a) Deve ser igual ou posterior à data de admissão/exercício do trabalhador;</xs:documentation>
-                                                            <xs:documentation>b) Se {cadIni}(2200_vinculo_cadIni) = [S], deve ser anterior à data de início da obrigatoriedade dos eventos não periódicos para o empregador;</xs:documentation>
-                                                            <xs:documentation>c) Se {cadIni}(2200_vinculo_cadIni) = [N], deve ser anterior à data da transferência do empregado ({sucessaoVinc/dtTransf}(2200_vinculo_sucessaoVinc_dtTransf) ou {transfDom/dtTransf}(2200_vinculo_transfDom_dtTransf)). Não informar se {tpAdmissao}(2200_vinculo_infoRegimeTrab_infoCeletista_tpAdmissao) = [1] ou se {tpProv}(2200_vinculo_infoRegimeTrab_infoEstatutario_tpProv) for diferente de [5, 8].</xs:documentation>
+                                                            <xs:documentation>b) Caso a situação no cadastro do CPF na RFB seja igual a "Titular Falecido", {dtDeslig}(./dtDeslig) deve ser igual ou anterior à data de óbito no cadastro do CPF da RFB (se não for possível obter a data do óbito, o ano de {dtDeslig}(./dtDeslig) deve ser igual ou anterior ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta);</xs:documentation>
+                                                            <xs:documentation>c) Se {cadIni}(2200_vinculo_cadIni) = [S], deve ser anterior à data de início da obrigatoriedade dos eventos não periódicos para o empregador;</xs:documentation>
+                                                            <xs:documentation>d) Se {cadIni}(2200_vinculo_cadIni) = [N], deve ser anterior à data da transferência do empregado ({sucessaoVinc/dtTransf}(2200_vinculo_sucessaoVinc_dtTransf) ou {transfDom/dtTransf}(2200_vinculo_transfDom_dtTransf)). Não informar se {tpAdmissao}(2200_vinculo_infoRegimeTrab_infoCeletista_tpAdmissao) = [1] ou se {tpProv}(2200_vinculo_infoRegimeTrab_infoEstatutario_tpProv) for diferente de [5, 8].</xs:documentation>
                                                         </xs:annotation>
                                                     </xs:element>
                                                 </xs:sequence>

--- a/schemes/v_S_01_03_00/evtAnotJud.xsd
+++ b/schemes/v_S_01_03_00/evtAnotJud.xsd
@@ -80,7 +80,7 @@
                                         <xs:element name="dtAdm" type="xs:date">
                                             <xs:annotation>
                                                 <xs:documentation>Preencher com a data de admissão do trabalhador.</xs:documentation>
-                                                <xs:documentation>Validação: Deve ser posterior à data de nascimento do trabalhador.</xs:documentation>
+                                                <xs:documentation>Validação: Deve ser posterior à data de nascimento do trabalhador e igual ou anterior à data do óbito, se existente (se não for possível obter a data do óbito, deve ser igual ou anterior ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta).</xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
                                         <xs:element name="matricula" type="TS_codigo_esocial">
@@ -244,8 +244,10 @@
                                                     <xs:element name="dtDeslig" type="xs:date">
                                                         <xs:annotation>
                                                             <xs:documentation>Preencher com a data de desligamento do vínculo (último dia trabalhado).</xs:documentation>
-                                                            <xs:documentation>Validação: Deve ser igual ou posterior à data de admissão do trabalhador e igual ou posterior a [2019-09-24].</xs:documentation>
-                                                            <xs:documentation>Não pode ser posterior à data atual.</xs:documentation>
+                                                            <xs:documentation>Validação: Deve ser igual ou posterior à data de admissão do trabalhador e igual ou posterior a [2019-09-24]. Não pode ser posterior à data atual.</xs:documentation>
+                                                            <xs:documentation>Se {mtvDeslig}(./mtvDeslig) = [10]:</xs:documentation>
+                                                            <xs:documentation>a) Caso a situação no cadastro do CPF na RFB seja diferente de "Titular Falecido", retornar erro até o 7º (sétimo) dia de {dtDeslig}(./dtDeslig) e retornar alerta a partir do 8º (oitavo) dia de {dtDeslig}(./dtDeslig);</xs:documentation>
+                                                            <xs:documentation>b) Caso a situação no cadastro do CPF na RFB seja igual a "Titular Falecido", {dtDeslig}(./dtDeslig) deve ser igual à data de óbito no cadastro do CPF da RFB (se não for possível obter a data do óbito, o ano de {dtDeslig}(./dtDeslig) deve ser igual ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta).</xs:documentation>
                                                         </xs:annotation>
                                                     </xs:element>
                                                     <xs:element name="dtProjFimAPI" type="TS_dtProjFimAPI" minOccurs="0" />

--- a/schemes/v_S_01_03_00/evtBaixa.xsd
+++ b/schemes/v_S_01_03_00/evtBaixa.xsd
@@ -40,6 +40,9 @@
                                             <xs:annotation>
                                                 <xs:documentation>Preencher com a data de desligamento do vínculo (último dia trabalhado).</xs:documentation>
                                                 <xs:documentation>Validação: Deve ser uma data igual ou posterior a 24/09/2019 e igual ou anterior à data atual. No caso de empregado reintegrado e quando não se tratar de retificação do desligamento anterior à reintegração, também deve ser uma data igual ou posterior a {dtEfetRetorno}(2298_infoReintegr_dtEfetRetorno) do evento S-2298.</xs:documentation>
+                                                <xs:documentation>Se {mtvDeslig}(./mtvDeslig) = [10]:</xs:documentation>
+                                                <xs:documentation>a) Caso a situação no cadastro do CPF na RFB seja diferente de "Titular Falecido", retornar erro até o 7º (sétimo) dia de {dtDeslig}(./dtDeslig) e retornar alerta a partir do 8º (oitavo) dia de {dtDeslig}(./dtDeslig);</xs:documentation>
+                                                <xs:documentation>b) Caso a situação no cadastro do CPF na RFB seja igual a "Titular Falecido", {dtDeslig}(./dtDeslig) deve ser igual à data de óbito no cadastro do CPF da RFB (se não for possível obter a data do óbito, o ano de {dtDeslig}(./dtDeslig) deve ser igual ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta).</xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
                                         <xs:element name="dtProjFimAPI" type="TS_dtProjFimAPI" minOccurs="0" />

--- a/schemes/v_S_01_03_00/evtBasesFGTS.xsd
+++ b/schemes/v_S_01_03_00/evtBasesFGTS.xsd
@@ -253,7 +253,7 @@
                                                                                                 <xs:documentation>Bases de cálculo e valores, exceto se {tpAcConv} = [E, H, I]</xs:documentation>
                                                                                                 <xs:documentation>DESCRICAO_COMPLETA:Informações sobre bases de cálculo e valores do FGTS referentes à remuneração do período de apuração e de períodos anteriores, exceto se {tpAcConv} = [E, H, I].</xs:documentation>
                                                                                                 <xs:documentation>Evento de origem: S-1200, S-2299 ou S-2399.</xs:documentation>
-                                                                                                <xs:documentation>CHAVE_GRUPO: {tpValor}, {indIncid}</xs:documentation>
+                                                                                                <xs:documentation>CHAVE_GRUPO: {tpValor}, {indIncid}, {notAFT}, {natRubr}</xs:documentation>
                                                                                                 <xs:documentation>CONDICAO_GRUPO: OC</xs:documentation>
                                                                                             </xs:annotation>
                                                                                             <xs:complexType>
@@ -435,6 +435,19 @@
                                                                                                             <xs:documentation>c) Se {tpValor}(./tpValor) = [41, 42, 43, 44, 45, 46, 47, 48, 49, 50], alíquota de 3,2%.</xs:documentation>
                                                                                                         </xs:annotation>
                                                                                                     </xs:element>
+                                                                                                    <xs:element name="notAFT" minOccurs="0" type="TS_notAFT">
+                                                                                                        <xs:annotation>
+                                                                                                            <xs:documentation>Número da notificação de FGTS que deu origem à confissão.</xs:documentation>
+                                                                                                            <xs:documentation>Evento de origem: S-1200, S-2299 ou S-2399.</xs:documentation>
+                                                                                                        </xs:annotation>
+                                                                                                    </xs:element>
+                                                                                                    <xs:element name="natRubr" minOccurs="0" type="TS_natRubr">
+                                                                                                        <xs:annotation>
+                                                                                                            <xs:documentation>Informar o código de classificação da rubrica.</xs:documentation>
+                                                                                                            <xs:documentation>Evento de origem: S-1010.</xs:documentation>
+                                                                                                            <xs:documentation>Validação: Retornar somente se {notAFT}(./notAFT) for informado.</xs:documentation>
+                                                                                                        </xs:annotation>
+                                                                                                    </xs:element>
                                                                                                     <xs:element name="detRubrSusp" minOccurs="0" maxOccurs="unbounded" type="T_detRubrSusp">
                                                                                                         <xs:annotation>
                                                                                                             <xs:documentation>Detalhamento da(s) rubrica(s) com incidência de FGTS suspensa</xs:documentation>
@@ -476,7 +489,13 @@
                                                                                                                         <xs:documentation>Tipo de valor que influi na apuração do FGTS.</xs:documentation>
                                                                                                                     </xs:annotation>
                                                                                                                 </xs:element>
-                                                                                                                <xs:element name="indIncidE" type="TS_indIncid" />
+                                                                                                                <xs:element name="indIncidE" type="TS_indIncid">
+                                                                                                                    <xs:annotation>
+                                                                                                                        <xs:documentation>Indicativo de incidência de FGTS.</xs:documentation>
+                                                                                                                        <xs:documentation>Validação: Se {codIncFGTS}(1010_infoRubrica_inclusao_dadosRubrica_codIncFGTS) em S-1010 for igual a [11, 12, 21], deve ser retornado [1].</xs:documentation>
+                                                                                                                        <xs:documentation>Se {codIncFGTS}(1010_infoRubrica_inclusao_dadosRubrica_codIncFGTS) em S-1010 for igual a [91, 92, 93], deve ser retornado [9].</xs:documentation>
+                                                                                                                    </xs:annotation>
+                                                                                                                </xs:element>
                                                                                                                 <xs:element name="remFGTSE" type="TS_valorMonetario_positivo">
                                                                                                                     <xs:annotation>
                                                                                                                         <xs:documentation>Remuneração (valor da base de cálculo) do FGTS, conforme definido nos campos {tpValorE}(./tpValorE) e {indIncidE}(./indIncidE).</xs:documentation>
@@ -541,8 +560,8 @@
                                                                                         <xs:element name="instFinanc">
                                                                                             <xs:simpleType>
                                                                                                 <xs:annotation>
-                                                                                                    <xs:documentation>Instituição financeira do empréstimo eConsignado.</xs:documentation>
-                                                                                                    <xs:documentation>Origem: campo {descFolha/instFinanc} dos eventos remuneratórios (S-1200, S-1202, S-1207, S-2299 e S-2399).</xs:documentation>
+                                                                                                    <xs:documentation>Código Bancário de Consignado concedente do empréstimo.</xs:documentation>
+                                                                                                    <xs:documentation>Origem: campo {descFolha/instFinanc} do evento remuneratório (S-1200, S-2299 ou S-2399).</xs:documentation>
                                                                                                 </xs:annotation>
                                                                                                 <xs:restriction base="xs:string">
                                                                                                     <xs:pattern value="\d{3}" />
@@ -553,10 +572,10 @@
                                                                                             <xs:simpleType>
                                                                                                 <xs:annotation>
                                                                                                     <xs:documentation>Número do contrato do empréstimo eConsignado.</xs:documentation>
-                                                                                                    <xs:documentation>Origem: campo {descFolha/nrDoc} dos eventos remuneratórios (S-1200, S-1202, S-1207, S-2299 e S-2399).</xs:documentation>
+                                                                                                    <xs:documentation>Origem: campo {descFolha/nrDoc} do evento remuneratório (S-1200, S-2299 ou S-2399).</xs:documentation>
                                                                                                 </xs:annotation>
                                                                                                 <xs:restriction base="xs:string">
-                                                                                                    <xs:minLength value="1" />
+                                                                                                    <xs:minLength value="2" />
                                                                                                     <xs:maxLength value="15" />
                                                                                                     <xs:pattern value="[A-Za-z0-9][-_A-Za-z0-9/.//]{0,13}[A-Za-z0-9]" />
                                                                                                 </xs:restriction>

--- a/schemes/v_S_01_03_00/evtBasesTrab.xsd
+++ b/schemes/v_S_01_03_00/evtBasesTrab.xsd
@@ -233,6 +233,11 @@
                                                             <xs:documentation>CP descontada do contribuinte individual, alíquota de 20% - 13º salário</xs:documentation>
                                                         </xs:annotation>
                                                     </xs:enumeration>
+                                                    <xs:enumeration value="160601">
+                                                        <xs:annotation>
+                                                            <xs:documentation>Empréstimo Consignado do Trabalhador, Lei nº 10.820/2003 (aplicável apenas ao DAE dos módulos simplificados)</xs:documentation>
+                                                        </xs:annotation>
+                                                    </xs:enumeration>
                                                 </xs:restriction>
                                             </xs:simpleType>
                                         </xs:element>
@@ -907,7 +912,7 @@
                                                     <xs:element name="nrInsc" type="TS_nrInsc_12_14">
                                                         <xs:annotation>
                                                             <xs:documentation>Informar o número de inscrição do contribuinte de acordo com o tipo de inscrição indicado no campo {ideEstab/tpInsc}(./tpInsc).</xs:documentation>
-                                                            <xs:documentation>Evento de origem: S-1200, S-2299, S-2399 ou S-1202</xs:documentation>
+                                                            <xs:documentation>Evento de origem: S-1200, S-2299, S-2399 ou S-1202.</xs:documentation>
                                                         </xs:annotation>
                                                     </xs:element>
                                                     <xs:element name="infoCategPisPasep" maxOccurs="10">

--- a/schemes/v_S_01_03_00/evtBenPrRP.xsd
+++ b/schemes/v_S_01_03_00/evtBenPrRP.xsd
@@ -22,6 +22,7 @@
                         <xs:documentation>REGRA:REGRA_REMUN_IND_RETIFICACAO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_REMUN_PERMITE_EXCLUSAO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_RUBRICA_COMPATIVEL_DECTERCEIRO</xs:documentation>
+                        <xs:documentation>REGRA:REGRA_RUBRICA_ECONSIGNADO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_VALIDA_EMPREGADOR</xs:documentation>
                         <xs:documentation>REGRA:REGRA_VALIDA_PERIODO_APURACAO</xs:documentation>
                     </xs:annotation>

--- a/schemes/v_S_01_03_00/evtCdBenAlt.xsd
+++ b/schemes/v_S_01_03_00/evtCdBenAlt.xsd
@@ -71,6 +71,23 @@
                                                         <xs:complexType>
                                                             <xs:sequence>
                                                                 <xs:element name="tpPenMorte" type="TS_tpPenMorte" />
+                                                                <xs:element name="instPenMorte" minOccurs="0">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>Informações do instituidor da pensão por morte.</xs:documentation>
+                                                                        <xs:documentation>CONDICAO_GRUPO: OC</xs:documentation>
+                                                                        <xs:documentation>Validação: Se o grupo não for informado e {dtAltBeneficio}(2416_infoBenAlteracao_dtAltBeneficio) >= [2025-11-24], retornar alerta.</xs:documentation>
+                                                                    </xs:annotation>
+                                                                    <xs:complexType>
+                                                                        <xs:sequence>
+                                                                            <xs:element name="tpDepInst" type="TS_tpDepInst">
+                                                                                <xs:annotation>
+                                                                                    <xs:documentation>Tipo de dependente do instituidor da pensão por morte.</xs:documentation>
+                                                                                </xs:annotation>
+                                                                            </xs:element>
+                                                                            <xs:element name="descrDepInst" minOccurs="0" type="TS_descrDepInst"/>
+                                                                        </xs:sequence>
+                                                                    </xs:complexType>
+                                                                </xs:element>
                                                             </xs:sequence>
                                                         </xs:complexType>
                                                     </xs:element>

--- a/schemes/v_S_01_03_00/evtCdBenIn.xsd
+++ b/schemes/v_S_01_03_00/evtCdBenIn.xsd
@@ -106,8 +106,9 @@
                                             <xs:annotation>
                                                 <xs:documentation>Data de início do benefício.</xs:documentation>
                                                 <xs:documentation>Validação: Deve observar o que segue:</xs:documentation>
-                                                <xs:documentation>a) Se {cadIni}(./cadIni) = [S], deve ser anterior à data de início da obrigatoriedade dos eventos não periódicos para o ente público no eSocial;</xs:documentation>
-                                                <xs:documentation>b) Se {cadIni}(./cadIni) = [N], deve ser igual ou posterior à data de início da obrigatoriedade dos eventos não periódicos para o ente público no eSocial e igual ou anterior à data atual.</xs:documentation>
+                                                <xs:documentation>a) Deve ser igual ou anterior à data do óbito, se existente (se não for possível obter a data do óbito, deve ser igual ou anterior ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta);</xs:documentation>
+                                                <xs:documentation>b) Se {cadIni}(./cadIni) = [S], deve ser anterior à data de início da obrigatoriedade dos eventos não periódicos para o ente público no eSocial;</xs:documentation>
+                                                <xs:documentation>c) Se {cadIni}(./cadIni) = [N], deve ser igual ou posterior à data de início da obrigatoriedade dos eventos não periódicos para o ente público no eSocial e igual ou anterior à data atual.</xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
                                         <xs:element name="dtPublic" type="xs:date" minOccurs="0">
@@ -167,6 +168,8 @@
                                                                                     <xs:documentation>Data de óbito do instituidor da pensão por morte.</xs:documentation>
                                                                                 </xs:annotation>
                                                                             </xs:element>
+                                                                            <xs:element name="tpDepInst" minOccurs="0" type="TS_tpDepInst"/>
+                                                                            <xs:element name="descrDepInst" minOccurs="0" type="TS_descrDepInst"/>
                                                                         </xs:sequence>
                                                                     </xs:complexType>
                                                                 </xs:element>
@@ -175,28 +178,42 @@
                                                     </xs:element>
                                                     <xs:element name="infoHomolog" minOccurs="0">
                                                         <xs:annotation>
-                                                            <xs:documentation>Informações relativas à homologação do benefício.</xs:documentation>
+                                                            <xs:documentation>Informações relativas à homologação do benefício pelo Tribunal de Contas.</xs:documentation>
                                                             <xs:documentation>CONDICAO_GRUPO: OC</xs:documentation>
+                                                            <xs:documentation>Validação: Se o grupo não for informado e {dtIniBeneficio}(2410_infoBenInicio_dtIniBeneficio) >= [2025-11-24], retornar alerta.</xs:documentation>
                                                         </xs:annotation>
                                                         <xs:complexType>
                                                             <xs:sequence>
                                                                 <xs:element name="sitHomolog">
                                                                     <xs:simpleType>
                                                                         <xs:annotation>
-                                                                            <xs:documentation>Situação relativa à homologação do benefício.</xs:documentation>
+                                                                            <xs:documentation>Informar se o benefício requer ou não homologação pelo Tribunal de Contas.</xs:documentation>
                                                                         </xs:annotation>
                                                                         <xs:restriction base="xs:byte">
-                                                                            <xs:enumeration value="0" />
-                                                                            <xs:enumeration value="1" />
-                                                                            <xs:enumeration value="2" />
+                                                                            <xs:enumeration value="0">
+                                                                                <xs:annotation>
+                                                                                    <xs:documentation>Não homologado</xs:documentation>
+                                                                                </xs:annotation>
+                                                                            </xs:enumeration>
+                                                                            <xs:enumeration value="1">
+                                                                                <xs:annotation>
+                                                                                    <xs:documentation>Homologado</xs:documentation>
+                                                                                </xs:annotation>
+                                                                            </xs:enumeration>
+                                                                            <xs:enumeration value="2">
+                                                                                <xs:annotation>
+                                                                                    <xs:documentation>Não requer homologação</xs:documentation>
+                                                                                </xs:annotation>
+                                                                            </xs:enumeration>
                                                                         </xs:restriction>
                                                                     </xs:simpleType>
                                                                 </xs:element>
-                                                                <xs:element name="dtHomolog" type="xs:date" minOccurs="0">
+                                                                <xs:element name="dtHomolog" minOccurs="0" type="xs:date">
                                                                     <xs:annotation>
-                                                                        <xs:documentation>Data de homologação do benefício.</xs:documentation>
+                                                                        <xs:documentation>Informar a data da homologação do benefício pelo Tribunal de Contas competente.</xs:documentation>
+                                                                        <xs:documentation>Validação: Informação obrigatória e exclusiva se {sitHomolog}(./sitHomolog) = [1].</xs:documentation>
                                                                     </xs:annotation>
-                                                                </xs:element>
+                                                                </xs:element>                                                                
                                                             </xs:sequence>
                                                         </xs:complexType>
                                                     </xs:element>
@@ -225,7 +242,7 @@
                                                         <xs:annotation>
                                                             <xs:documentation>Preencher com a data da transferência do benefício para o órgão público declarante.</xs:documentation>
                                                             <xs:documentation>Validação: Devem ser observadas as seguintes regras:</xs:documentation>
-                                                            <xs:documentation>a) Deve ser posterior à data de início do benefício;</xs:documentation>
+                                                            <xs:documentation>a) Deve ser posterior à data de início do benefício e igual ou anterior à data do óbito, se existente (se não for possível obter a data do óbito, deve ser igual ou anterior ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta);</xs:documentation>
                                                             <xs:documentation>b) Deve ser igual ou posterior à data de início da obrigatoriedade dos eventos não periódicos para o ente público no eSocial e igual ou anterior à data atual.</xs:documentation>
                                                         </xs:annotation>
                                                     </xs:element>
@@ -274,7 +291,10 @@
                                                             <xs:documentation>Validação: Devem ser observadas as seguintes regras:</xs:documentation>
                                                             <xs:documentation>a) Deve ser igual ou posterior à data de início do benefício;</xs:documentation>
                                                             <xs:documentation>b) Se {cadIni}(2410_infoBenInicio_cadIni) = [S], deve ser anterior à data de início da obrigatoriedade dos eventos não periódicos para o ente público no eSocial;</xs:documentation>
-                                                            <xs:documentation>c) Se {indSitBenef}(2410_infoBenInicio_indSitBenef) = [2], deve ser anterior a {dtTransf}(2410_infoBenInicio_sucessaoBenef_dtTransf).</xs:documentation>
+                                                            <xs:documentation>c) Se {indSitBenef}(2410_infoBenInicio_indSitBenef) = [2], deve ser anterior a {dtTransf}(2410_infoBenInicio_sucessaoBenef_dtTransf);</xs:documentation>
+                                                            <xs:documentation>d) Se {mtvTermino}(./mtvTermino) = [01]:</xs:documentation>
+                                                            <xs:documentation>d1) Caso a situação no cadastro do CPF na RFB seja diferente de "Titular Falecido", retornar erro até o 7º (sétimo) dia de {dtTermBeneficio}(./dtTermBeneficio) e retornar alerta a partir do 8º (oitavo) dia de {dtTermBeneficio}(./dtTermBeneficio);</xs:documentation>
+                                                            <xs:documentation>d2) Caso a situação no cadastro do CPF na RFB seja igual a "Titular Falecido", {dtTermBeneficio}(./dtTermBeneficio) deve ser igual à data de óbito no cadastro do CPF da RFB (se não for possível obter a data do óbito, o ano de {dtTermBeneficio}(./dtTermBeneficio) deve ser igual ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta).</xs:documentation>
                                                         </xs:annotation>
                                                     </xs:element>
                                                     <xs:element name="mtvTermino">

--- a/schemes/v_S_01_03_00/evtCdBenTerm.xsd
+++ b/schemes/v_S_01_03_00/evtCdBenTerm.xsd
@@ -38,6 +38,9 @@
                                             <xs:annotation>
                                                 <xs:documentation>Data de cessação do benefício.</xs:documentation>
                                                 <xs:documentation>Validação: Deve ser igual ou anterior à data atual. No caso de benefício reativado, também deve ser uma data igual ou posterior a {dtEfetReativ}(2418_infoReativ_dtEfetReativ) do evento S-2418.</xs:documentation>
+                                                <xs:documentation>Se {mtvTermino}(./mtvTermino) = [01]:</xs:documentation>
+                                                <xs:documentation>a) Caso a situação no cadastro do CPF na RFB seja diferente de "Titular Falecido", retornar erro até o 7º (sétimo) dia de {dtTermBeneficio}(./dtTermBeneficio) e retornar alerta a partir do 8º (oitavo) dia de {dtTermBeneficio}(./dtTermBeneficio);</xs:documentation>
+                                                <xs:documentation>b) Caso a situação no cadastro do CPF na RFB seja igual a "Titular Falecido", {dtTermBeneficio}(./dtTermBeneficio) deve ser igual à data de óbito no cadastro do CPF da RFB (se não for possível obter a data do óbito, o ano de {dtTermBeneficio}(./dtTermBeneficio) deve ser igual ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta).</xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
                                         <xs:element name="mtvTermino">

--- a/schemes/v_S_01_03_00/evtCdBenefIn.xsd
+++ b/schemes/v_S_01_03_00/evtCdBenefIn.xsd
@@ -31,16 +31,11 @@
                                 <xs:complexType>
                                     <xs:sequence>
                                         <xs:element name="tpInsc" type="TS_tpInsc_1" />
-                                        <xs:element name="nrInsc">
-                                            <xs:simpleType>
-                                                <xs:annotation>
-                                                    <xs:documentation>Informar o número de inscrição do contribuinte de acordo com o tipo de inscrição indicado no campo {ideEmpregador/tpInsc}(./tpInsc) e conforme informado em S-1000.</xs:documentation>
-                                                    <xs:documentation>Validação: A natureza jurídica relativa ao número de inscrição informado deve ser igual a 1XX-X, 201-1, 203-8 ou 307-7.</xs:documentation>
-                                                </xs:annotation>
-                                                <xs:restriction base="xs:string">
-                                                    <xs:pattern value="\d{8}|\d{14}" />
-                                                </xs:restriction>
-                                            </xs:simpleType>
+                                        <xs:element name="nrInsc" type="TS_nrInsc_8_14">
+                                            <xs:annotation>
+                                                <xs:documentation>Informar o número de inscrição do contribuinte de acordo com o tipo de inscrição indicado no campo {ideEmpregador/tpInsc}(./tpInsc) e conforme informado em S-1000.</xs:documentation>
+                                                <xs:documentation>Validação: A natureza jurídica relativa ao número de inscrição informado deve ser igual a 1XX-X, 201-1, 203-8 ou 307-7.</xs:documentation>
+                                            </xs:annotation>
                                         </xs:element>
                                     </xs:sequence>
                                 </xs:complexType>

--- a/schemes/v_S_01_03_00/evtConsolidContProc.xsd
+++ b/schemes/v_S_01_03_00/evtConsolidContProc.xsd
@@ -19,7 +19,7 @@
                     </xs:annotation>
                     <xs:complexType>
                         <xs:sequence>
-                            <xs:element name="ideEvento" type="T_ideEvento_exclusao" />
+                            <xs:element name="ideEvento" type="T_ideEvento_exclusao_proc_trab" />
                             <xs:element name="ideEmpregador">
                                 <xs:annotation>
                                     <xs:documentation>Informações de identificação do empregador ou do contribuinte que está prestando a informação.</xs:documentation>

--- a/schemes/v_S_01_03_00/evtContProc.xsd
+++ b/schemes/v_S_01_03_00/evtContProc.xsd
@@ -15,6 +15,7 @@
                         <xs:documentation>REGRA:REGRA_ENVIO_PROC_FECHAMENTO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_EXC_RET_2501</xs:documentation>
                         <xs:documentation>REGRA:REGRA_EXISTE_INFO_EMPREGADOR</xs:documentation>
+                        <xs:documentation>REGRA:REGRA_RETIFICA_IDENTIFICADOR</xs:documentation>
                         <xs:documentation>REGRA:REGRA_VALIDA_EMPREGADOR</xs:documentation>
                     </xs:annotation>
                     <xs:complexType>
@@ -50,7 +51,7 @@
                                         <xs:element name="nrProcTrab" type="TS_nrProcTrab">
                                             <xs:annotation>
                                                 <xs:documentation>Número do processo trabalhista, da ata ou número de identificação da conciliação.</xs:documentation>
-                                                <xs:documentation>Validação: Deve ser um número de processo válido e declarado no evento S-2500 para o(s) trabalhador(es) informado(s) em {cpfTrab}(2501_ideTrab_cpfTrab).</xs:documentation>
+                                                <xs:documentation>Validação: Deve ser um número de processo válido e declarado no evento S-2500 para o(s) trabalhador(es) informado(s) em {cpfTrab}(2501_ideTrab_cpfTrab), com {origem}(2500_infoProcesso_origem) em S-2500 diferente de [3].</xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
                                         <xs:element name="perApurPgto" type="TS_periodo_mensal">
@@ -132,7 +133,7 @@
                                                 <xs:attribute name="perRef" use="required">
                                                     <xs:annotation>
                                                         <xs:documentation>Informar o mês/ano (formato AAAA-MM) de referência das informações.</xs:documentation>
-                                                        <xs:documentation>Validação: Deve ser um período existente no evento S-2500 para o trabalhador indicado em {cpfTrab}(../cpfTrab) (observado o campo {}(2500_ideTrab_ideSeqTrab) de S-2500, se existente) e igual ou posterior a [2008-12].</xs:documentation>
+                                                        <xs:documentation>Validação: Deve ser um período existente no evento S-2500 para o trabalhador indicado em {cpfTrab}(../cpfTrab) (observado o campo {}(2500_ideTrab_ideSeqTrab) de S-2500, se existente), igual ou posterior a [2008-12] e igual ou anterior a {perApurPgto}(2501_ideProc_perApurPgto).</xs:documentation>
                                                     </xs:annotation>
                                                     <xs:simpleType>
                                                         <xs:restriction base="TS_periodo_mensal" />

--- a/schemes/v_S_01_03_00/evtDeslig.xsd
+++ b/schemes/v_S_01_03_00/evtDeslig.xsd
@@ -34,6 +34,7 @@
                         <xs:documentation>REGRA:REGRA_RETIFICA_MESMO_VINCULO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_RUBRICA_COMPATIVEL_CATEGORIA</xs:documentation>
                         <xs:documentation>REGRA:REGRA_RUBRICA_ECONSIGNADO</xs:documentation>
+                        <xs:documentation>REGRA:REGRA_VALIDA_CODINCCP_EXC_SEGURADO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_VALIDA_EMPREGADOR</xs:documentation>
                         <xs:documentation>REGRA:REGRA_VALIDA_PERIODO_APURACAO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_VINCULO_ATIVO_NA_DTEVENTO</xs:documentation>
@@ -65,6 +66,9 @@
                                             <xs:annotation>
                                                 <xs:documentation>Preencher com a data de desligamento do vínculo (último dia trabalhado).</xs:documentation>
                                                 <xs:documentation>Validação: Deve ser uma data igual ou anterior à data atual acrescida de 10 (dez) dias. No caso de empregado reintegrado e quando não se tratar de retificação do desligamento anterior à reintegração, também deve ser uma data igual ou posterior a {dtEfetRetorno}(2298_infoReintegr_dtEfetRetorno) do evento S-2298.</xs:documentation>
+                                                <xs:documentation>Se {mtvDeslig}(./mtvDeslig) = [10]:</xs:documentation>
+                                                <xs:documentation>a) Caso a situação no cadastro do CPF na RFB seja diferente de "Titular Falecido", retornar erro até o 7º (sétimo) dia de {dtDeslig}(./dtDeslig) e retornar alerta a partir do 8º (oitavo) dia de {dtDeslig}(./dtDeslig);</xs:documentation>
+                                                <xs:documentation>b) Caso a situação no cadastro do CPF na RFB seja igual a "Titular Falecido", {dtDeslig}(./dtDeslig) deve ser igual à data de óbito no cadastro do CPF da RFB (se não for possível obter a data do óbito, o ano de {dtDeslig}(./dtDeslig) deve ser igual ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta).</xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
                                         <xs:element name="dtAvPrv" minOccurs="0" type="xs:date">
@@ -139,7 +143,7 @@
                                                         <xs:annotation>
                                                             <xs:documentation>Informar o número de inscrição do empregador sucessor, de acordo com o tipo de inscrição indicado no campo {sucessaoVinc/tpInsc}(./tpInsc).</xs:documentation>
                                                             <xs:documentation>Validação: Deve ser um número de inscrição válido e diferente da inscrição do declarante, considerando as particularidades aplicadas à informação de CNPJ de órgão público em S-1000.</xs:documentation>
-                                                            <xs:documentation>Se {sucessaoVinc/tpInsc}(./tpInsc) = [1], deve possuir 14 (catorze) algarismos e ser diferente do CNPJ base do empregador (exceto se {ideEmpregador/nrInsc}(2299_ideEmpregador_nrInsc) tiver 14 (catorze) algarismos) e dos estabelecimentos informados através do evento S-1005.</xs:documentation>
+                                                            <xs:documentation>Se {sucessaoVinc/tpInsc}(./tpInsc) = [1], deve possuir 14 (catorze) algarismos e ser diferente do CNPJ base do empregador (exceto se {ideEmpregador/nrInsc}(2299_ideEmpregador_nrInsc) tiver 14 (catorze) algarismos). Também deve ser diferente dos estabelecimentos informados através do evento S-1005, exceto se a natureza jurídica do declarante for Administração Pública (grupo [1]).</xs:documentation>
                                                             <xs:documentation>Se {sucessaoVinc/tpInsc}(./tpInsc) = [2], deve possuir 11 (onze) algarismos.</xs:documentation>
                                                         </xs:annotation>
                                                     </xs:element>
@@ -215,6 +219,14 @@
                                                                         <xs:documentation>Somente preencher este campo se for um demonstrativo de RRA.</xs:documentation>
                                                                     </xs:annotation>
                                                                 </xs:element>
+                                                                <xs:element name="notAFT" minOccurs="0" type="TS_notAFT">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>Número da notificação de FGTS que deu origem à confissão.</xs:documentation>
+                                                                        <xs:documentation>Validação: Se o campo for preenchido:</xs:documentation>
+                                                                        <xs:documentation>a) O mês/ano de {}(2299_infoDeslig_dtDeslig) deve ser igual ou posterior ao início do FGTS Digital;</xs:documentation>
+                                                                        <xs:documentation>b) Devem ser informados apenas caracteres alfanuméricos, com 9 (nove) posições.</xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:element>
                                                                 <xs:element name="infoRRA" minOccurs="0" type="T_infoRRA" />
                                                                 <xs:element name="infoPerApur" minOccurs="0">
                                                                     <xs:annotation>
@@ -237,7 +249,7 @@
                                                                     <xs:annotation>
                                                                         <xs:documentation>Informações relativas a períodos anteriores</xs:documentation>
                                                                         <xs:documentation>DESCRICAO_COMPLETA:Remuneração relativa a períodos anteriores, devida em função de acordos coletivos, legislação específica, convenção coletiva de trabalho, dissídio ou conversão de licença saúde em acidente de trabalho.</xs:documentation>
-                                                                        <xs:documentation>CONDICAO_GRUPO: O (se não existir o grupo {infoPerApur}(2299_infoDeslig_verbasResc_dmDev_infoPerApur)); OC (nos demais casos)</xs:documentation>
+                                                                        <xs:documentation>CONDICAO_GRUPO: N (se {}(2299_infoDeslig_verbasResc_dmDev_notAFT) for informado); O (se não existir o grupo {infoPerApur}(2299_infoDeslig_verbasResc_dmDev_infoPerApur)); OC (nos demais casos)</xs:documentation>
                                                                     </xs:annotation>
                                                                     <xs:complexType>
                                                                         <xs:sequence>
@@ -434,7 +446,7 @@
                                                                 <xs:documentation>Número do contrato de empréstimo consignado existente na instituição consignatária.</xs:documentation>
                                                             </xs:annotation>
                                                             <xs:restriction base="xs:string">
-                                                                <xs:pattern value="[A-Za-z0-9]{1,40}" />
+                                                                <xs:pattern value="\d{1,40}" />
                                                             </xs:restriction>
                                                         </xs:simpleType>
                                                     </xs:element>
@@ -469,7 +481,7 @@
             <xs:element name="codLotacao" type="TS_codLotacao" />
             <xs:element name="detVerbas" maxOccurs="200" type="T_detVerbas_descFolha" />
             <xs:element name="infoAgNocivo" minOccurs="0" type="T_infoAgNocivo" />
-            <xs:element name="infoSimples" minOccurs="0" type="T_infoSimples" />
+            <xs:element name="infoSimples" minOccurs="0" type="T_infoSimples_S-2299" />
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="T_ideEstabLot_infoPerAnt">
@@ -479,7 +491,7 @@
             <xs:element name="codLotacao" type="TS_codLotacao" />
             <xs:element name="detVerbas" maxOccurs="200" type="T_detVerbas" />
             <xs:element name="infoAgNocivo" minOccurs="0" type="T_infoAgNocivo" />
-            <xs:element name="infoSimples" minOccurs="0" type="T_infoSimples" />
+            <xs:element name="infoSimples" minOccurs="0" type="T_infoSimples_S-2299" />
         </xs:sequence>
     </xs:complexType>
     <xs:complexType name="T_detVerbas">
@@ -510,7 +522,29 @@
         <xs:complexContent>
             <xs:extension base="T_detVerbas">
                 <xs:sequence>
-                    <xs:element name="descFolha" minOccurs="0" type="T_descFolha" />
+                    <xs:element name="descFolha" minOccurs="0">
+                        <xs:annotation>
+                            <xs:documentation>Informações de desconto do empréstimo em folha.</xs:documentation>
+                            <xs:documentation>CONDICAO_GRUPO: O (se {}(1010_infoRubrica_inclusao_dadosRubrica_natRubr) em S-1010 = [9253]); N (nos demais casos)</xs:documentation>
+                        </xs:annotation>
+                        <xs:complexType>
+                            <xs:sequence>
+                                <xs:element name="tpDesc" type="TS_tpDesc" />
+                                <xs:element name="instFinanc" type="TS_instFinanc">
+                                    <xs:annotation>
+                                        <xs:documentation>Código Bancário de Consignado concedente do empréstimo.</xs:documentation>
+                                        <xs:documentation>Validação: Deve ser um código válido, conforme Tabela  37 do eSocial Tabelas.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:element>    
+                                <xs:element name="nrDoc" type="TS_nrDoc" />
+                                <xs:element name="observacao" minOccurs="0" type="TS_observacao">
+                                    <xs:annotation>
+                                        <xs:documentation>Outras informações do desconto.</xs:documentation>
+                                    </xs:annotation>
+                                </xs:element>
+                            </xs:sequence>
+                        </xs:complexType>
+                    </xs:element>
                 </xs:sequence>
             </xs:extension>
         </xs:complexContent>

--- a/schemes/v_S_01_03_00/evtFGTS.xsd
+++ b/schemes/v_S_01_03_00/evtFGTS.xsd
@@ -109,7 +109,7 @@
                                                                                     <xs:documentation>Bases de cálculo e valores do FGTS, exceto se {tpAcConv} = [E, H, I]</xs:documentation>
                                                                                     <xs:documentation>DESCRICAO_COMPLETA:Informações consolidadas das bases de cálculo e valores do FGTS do período de apuração e de períodos anteriores, exceto se {tpAcConv} = [E, H, I].</xs:documentation>
                                                                                     <xs:documentation>Evento de origem: S-1270 ou S-5003.</xs:documentation>
-                                                                                    <xs:documentation>CHAVE_GRUPO: {tpValor}, {indIncid}</xs:documentation>
+                                                                                    <xs:documentation>CHAVE_GRUPO: {tpValor}, {indIncid}, {notAFT}, {natRubr}</xs:documentation>
                                                                                     <xs:documentation>CONDICAO_GRUPO: OC</xs:documentation>
                                                                                 </xs:annotation>
                                                                                 <xs:complexType>
@@ -301,6 +301,18 @@
                                                                                                 <xs:documentation>Validação: Deve ser maior que 0 (zero).</xs:documentation>
                                                                                                 <xs:documentation>Se {tpValor}(./tpValor) for diferente de [19], deve corresponder ao somatório dos valores informados no campo {dpsFGTS}(5003_infoFGTS_ideEstab_ideLotacao_infoTrabFGTS_infoBaseFGTS_basePerApur_dpsFGTS) do evento S-5003, agrupados por {tpValor}(./tpValor).</xs:documentation>
                                                                                                 <xs:documentation>Se {tpValor}(./tpValor) = [19], deve corresponder ao somatório dos valores informados no campo {baseFGTS}(./baseFGTS), e aplicar a alíquota de 8%.</xs:documentation>
+                                                                                            </xs:annotation>
+                                                                                        </xs:element>
+                                                                                        <xs:element name="notAFT" minOccurs="0" type="TS_notAFT">
+                                                                                            <xs:annotation>
+                                                                                                <xs:documentation>Número da notificação de FGTS que deu origem à confissão.</xs:documentation>
+                                                                                                <xs:documentation>Evento de origem: S-5003.</xs:documentation>
+                                                                                            </xs:annotation>
+                                                                                        </xs:element>
+                                                                                        <xs:element name="natRubr" minOccurs="0" type="TS_natRubr">
+                                                                                            <xs:annotation>
+                                                                                                <xs:documentation>Informar o código de classificação da rubrica.</xs:documentation>
+                                                                                                <xs:documentation>Evento de origem: S-5003.</xs:documentation>
                                                                                             </xs:annotation>
                                                                                         </xs:element>
                                                                                     </xs:sequence>

--- a/schemes/v_S_01_03_00/evtIrrfBenef.xsd
+++ b/schemes/v_S_01_03_00/evtIrrfBenef.xsd
@@ -912,6 +912,7 @@
                                                             <xs:documentation>Totalizador de rendimentos tributáveis e tributos com período de apuração diário.</xs:documentation>
                                                             <xs:documentation>CHAVE_GRUPO: {perApurDia}, {CRDia}, {frmTribut}, {paisResidExt}</xs:documentation>
                                                             <xs:documentation>CONDICAO_GRUPO: OC</xs:documentation>
+                                                            <xs:documentation>Validação: Em uma mesma ocorrência deste grupo, se {perApur}(5002_ideEvento_perApur) for igual ou posterior ao início da DIRF, deve haver compatibilidade entre a forma de tributação e o tipo de rendimento (tributável ou isento/não tributável).</xs:documentation>
                                                         </xs:annotation>
                                                         <xs:complexType>
                                                             <xs:sequence>

--- a/schemes/v_S_01_03_00/evtPgtos.xsd
+++ b/schemes/v_S_01_03_00/evtPgtos.xsd
@@ -145,7 +145,12 @@
                                                                     <xs:simpleType>
                                                                         <xs:annotation>
                                                                             <xs:documentation>Forma de tributação, conforme opções disponíveis na Tabela 30.</xs:documentation>
-                                                                            <xs:documentation>Validação: Deve ser um código válido e existente na Tabela 30. Para os códigos [1X, 30], deve existir informação relativa ao imposto retido na fonte; para os códigos [4X, 50] não é permitida a informação do imposto retido na fonte.</xs:documentation>
+                                                                            <xs:documentation>Validação: Deve ser um código válido e existente na Tabela 30.</xs:documentation>
+                                                                            <xs:documentation>Para os códigos [1X, 3X], deve existir informação relativa ao imposto retido na fonte.</xs:documentation>
+                                                                            <xs:documentation>Para os códigos [4X, 5X]:</xs:documentation>
+                                                                            <xs:documentation>a) Não é permitida a informação do imposto retido na fonte;</xs:documentation>
+                                                                            <xs:documentation>b) Se {perApur}(1210_ideEvento_perApur) >= [2025-01], não pode existir informação relativa a rendimento tributável ({codIncIRRF}(1010_infoRubrica_inclusao_dadosRubrica_codIncIRRF) em S-1010 = [11, 12, 13, 14] e {indApurIR} do evento remuneratório = [0]).</xs:documentation>
+                                                                            <xs:documentation>Referente à validação da alínea "b", retornar alerta se {perApur}(1210_ideEvento_perApur) &lt;= [2025-12] e retornar erro se {perApur}(1210_ideEvento_perApur) >= [2026-01].</xs:documentation>
                                                                         </xs:annotation>
                                                                         <xs:restriction base="xs:string">
                                                                             <xs:pattern value="\d{2}" />

--- a/schemes/v_S_01_03_00/evtProcTrab.xsd
+++ b/schemes/v_S_01_03_00/evtProcTrab.xsd
@@ -17,8 +17,10 @@
                         <xs:documentation>REGRA:REGRA_ENVIO_PROC_FECHAMENTO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_EVENTOS_EXTEMP</xs:documentation>
                         <xs:documentation>REGRA:REGRA_EXISTE_INFO_EMPREGADOR</xs:documentation>
+                        <xs:documentation>REGRA:REGRA_INFO_IDESEQTRAB</xs:documentation>
                         <xs:documentation>REGRA:REGRA_MESMO_PROCEMI</xs:documentation>
                         <xs:documentation>REGRA:REGRA_MUDANCA_CATEG_NAT_ATIV</xs:documentation>
+                        <xs:documentation>REGRA:REGRA_RETIFICA_IDENTIFICADOR</xs:documentation>
                         <xs:documentation>REGRA:REGRA_RETIFICA_MESMO_VINCULO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_UNICIDADE_CONTRATUAL</xs:documentation>
                         <xs:documentation>REGRA:REGRA_VALIDA_EMPREGADOR</xs:documentation>
@@ -67,7 +69,8 @@
                                                         <xs:annotation>
                                                             <xs:documentation>Preencher com a data de admissão do trabalhador no empregador de origem (responsável direto) quando se tratar de vínculo que não foi informado no eSocial.</xs:documentation>
                                                             <xs:documentation>Em caso de TSVE sem informação de matrícula no evento S-2300, informar a data de início.</xs:documentation>
-                                                            <xs:documentation>Validação: Se informado, deve ser posterior à data de nascimento do trabalhador e igual ou anterior ao ano do óbito, se existente. Não deve ser informado se houver informação no campo {}(./matRespDir).</xs:documentation>
+                                                            <xs:documentation>Validação: Se informado, deve ser posterior à data de nascimento do trabalhador e igual ou anterior à data do óbito, se existente (se não for possível obter a data do óbito, deve ser igual ou anterior ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta).</xs:documentation>
+                                                            <xs:documentation>Não deve ser informado se houver informação no campo {}(./matRespDir).</xs:documentation>
                                                         </xs:annotation>
                                                     </xs:element>
                                                     <xs:element name="matRespDir" minOccurs="0" type="TS_matricula">
@@ -94,7 +97,10 @@
                                         <xs:element name="nrProcTrab" type="TS_nrProcTrab">
                                             <xs:annotation>
                                                 <xs:documentation>Número do processo trabalhista, da ata ou número de identificação da conciliação.</xs:documentation>
-                                                <xs:documentation>Validação: Se {origem}(./origem) = [1], deve ser um processo judicial válido, com 20 (vinte) algarismos. Se {origem}(./origem) = [2], deve possuir 15 (quinze) algarismos.</xs:documentation>
+                                                <xs:documentation>Validação: Se {origem}(./origem) = [1, 3], deve ser um processo judicial válido, com 20 (vinte) algarismos. Se {origem}(./origem) = [2], deve possuir 15 (quinze) algarismos.</xs:documentation>
+                                                <xs:documentation>Além disso, caso {dtSent}(2500_infoProcesso_dadosCompl_infoProcJud_dtSent) >= [2026-04-27]:</xs:documentation>
+                                                <xs:documentation>a) Se {origem}(./origem) = [1], o 14º (décimo quarto) algarismo deve ser igual a "5";</xs:documentation>
+                                                <xs:documentation>b) Se {origem}(./origem) = [3], o 14º (décimo quarto) algarismo deve ser igual a "4" ou "8".</xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
                                         <xs:element name="obsProcTrab" minOccurs="0" type="TS_texto_999">
@@ -112,7 +118,7 @@
                                                         <xs:element name="infoProcJud">
                                                             <xs:annotation>
                                                                 <xs:documentation>Informações complementares do processo judicial.</xs:documentation>
-                                                                <xs:documentation>CONDICAO_GRUPO: O (se {origem}(2500_infoProcesso_origem) = [1]); N (nos demais casos)</xs:documentation>
+                                                                <xs:documentation>CONDICAO_GRUPO: O (se {origem}(2500_infoProcesso_origem) = [1, 3]); N (nos demais casos)</xs:documentation>
                                                             </xs:annotation>
                                                             <xs:complexType>
                                                                 <xs:sequence>
@@ -140,6 +146,12 @@
                                                                                 <xs:pattern value="\d{1,4}" />
                                                                             </xs:restriction>
                                                                         </xs:simpleType>
+                                                                    </xs:element>
+                                                                    <xs:element name="infoPatPrec" type="TS_valorMonetario" minOccurs="0">
+                                                                        <xs:annotation>
+                                                                            <xs:documentation>Valor total da cota patronal incidente sobre a remuneração paga ao trabalhador, que será objeto de requisição autônoma.</xs:documentation>
+                                                                            <xs:documentation>Validação: Preenchimento obrigatório e exclusivo se {origem}(../../origem) = [3].</xs:documentation>
+                                                                        </xs:annotation>
                                                                     </xs:element>
                                                                 </xs:sequence>
                                                             </xs:complexType>
@@ -243,7 +255,7 @@
                                                         <xs:simpleType>
                                                             <xs:annotation>
                                                                 <xs:documentation>Tipo de contrato a que se refere o processo judicial ou a demanda submetida à CCP ou ao NINTER.</xs:documentation>
-                                                                <xs:documentation>Validação: Deve ser igual a [6, 8] se o grupo {ideResp}(2500_ideEmpregador_ideResp) for informado.</xs:documentation>
+                                                                <xs:documentation>Validação: Deve ser igual a [6, 8] se o grupo {ideResp}(2500_ideEmpregador_ideResp) for informado. Além disso, se {origem}(2500_infoProcesso_origem) = [3], deve ser igual a [1].</xs:documentation>
                                                             </xs:annotation>
                                                             <xs:restriction base="xs:byte">
                                                                 <xs:enumeration value="1">
@@ -357,7 +369,7 @@
                                                             <xs:documentation>e) Para o trabalhador avulso, a data de ingresso no Órgão Gestor de Mão de Obra - OGMO ou no sindicato;</xs:documentation>
                                                             <xs:documentation>f) Para o servidor público exercente de cargo eletivo, a data de início do mandato;</xs:documentation>
                                                             <xs:documentation>g) Para os demais trabalhadores, a data de início das atividades.</xs:documentation>
-                                                            <xs:documentation>Validação: Informação obrigatória e exclusiva se ({infoContr/tpContr}(./tpContr) = [6] e {indContr}(./indContr) = [N]) ou se o campo {matricula}(./matricula) não estiver preenchido. Deve ser posterior à data de nascimento do trabalhador. Se o campo {matricula}(./matricula) não estiver preenchido, deve ser igual à data de início informada no evento S-2300.</xs:documentation>
+                                                            <xs:documentation>Validação: Informação obrigatória e exclusiva se ({infoContr/tpContr}(./tpContr) = [6] e {indContr}(./indContr) = [N]) ou se o campo {matricula}(./matricula) não estiver preenchido. Deve ser posterior à data de nascimento do trabalhador e igual ou anterior à data do óbito, se existente (se não for possível obter a data do óbito, deve ser igual ou anterior ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta). Se o campo {matricula}(./matricula) não estiver preenchido, deve ser igual à data de início informada no evento S-2300.</xs:documentation>
                                                         </xs:annotation>
                                                     </xs:element>
                                                     <xs:element name="infoCompl" minOccurs="0">
@@ -432,7 +444,7 @@
                                                                             <xs:element name="dtAdm" type="xs:date">
                                                                                 <xs:annotation>
                                                                                     <xs:documentation>Preencher com a data de admissão do trabalhador.</xs:documentation>
-                                                                                    <xs:documentation>Validação: Deve ser posterior à data de nascimento do trabalhador e igual ou anterior ao ano do óbito, se existente.</xs:documentation>
+                                                                                    <xs:documentation>Validação: Deve ser posterior à data de nascimento do trabalhador e igual ou anterior à data do óbito, se existente (se não for possível obter a data do óbito, deve ser igual ou anterior ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta).</xs:documentation>
                                                                                 </xs:annotation>
                                                                             </xs:element>
                                                                             <xs:element name="tmpParc" minOccurs="0" type="TS_tmpParc">
@@ -453,7 +465,7 @@
                                                                                         <xs:element name="dtTerm" minOccurs="0" type="TS_dtTerm">
                                                                                             <xs:annotation>
                                                                                                 <xs:documentation>Data do término do contrato por prazo determinado.</xs:documentation>
-                                                                                                <xs:documentation>Validação: O preenchimento é obrigatório se {duracao/tpContr}(./tpContr) = [2]. Não informar se {duracao/tpContr}(./tpContr) = [1]. Se preenchido, deve ser igual ou posterior à data de admissão (no caso de transferência, igual ou posterior a {sucessaoVinc/dtTransf}(../sucessaoVinc_dtTransf)).</xs:documentation>
+                                                                                                <xs:documentation>Validação: O preenchimento é obrigatório se {duracao/tpContr}(./tpContr) = [2]. Não informar se {duracao/tpContr}(./tpContr) = [1]. Se preenchido, deve ser igual ou posterior à data de admissão (no caso de transferência, igual ou posterior a {dtTransf}(../sucessaoVinc_dtTransf)).</xs:documentation>
                                                                                             </xs:annotation>
                                                                                         </xs:element>
                                                                                         <xs:element name="clauAssec" minOccurs="0" type="TS_sim_nao">
@@ -534,20 +546,20 @@
                                                                                                     <xs:documentation>Se {sucessaoVinc/tpInsc}(./tpInsc) = [6], deve possuir 12 (doze) algarismos.</xs:documentation>
                                                                                                 </xs:annotation>
                                                                                                 <xs:restriction base="xs:string">
-                                                                                                    <xs:pattern value="\d{8,14}" />
+                                                                                                    <xs:pattern value="\d{8,14}|[A-Z0-9]{12}\d{2}" />
                                                                                                 </xs:restriction>
                                                                                             </xs:simpleType>
                                                                                         </xs:element>
                                                                                         <xs:element name="matricAnt" minOccurs="0" type="TS_matricula">
                                                                                             <xs:annotation>
                                                                                                 <xs:documentation>Matrícula do trabalhador no empregador anterior.</xs:documentation>
-                                                                                                <xs:documentation>Validação: Se {sucessaoVinc/dtTransf}(./dtTransf) for igual ou posterior a [2024-04-22], a matrícula informada neste campo deve ser idêntica à matricula do trabalhador no empregador anterior.</xs:documentation>
+                                                                                                <xs:documentation>Validação: Se {dtTransf}(./dtTransf) for igual ou posterior a [2024-04-22], a matrícula informada neste campo deve ser idêntica à matricula do trabalhador no empregador anterior.</xs:documentation>
                                                                                             </xs:annotation>
                                                                                         </xs:element>
                                                                                         <xs:element name="dtTransf" type="xs:date">
                                                                                             <xs:annotation>
                                                                                                 <xs:documentation>Preencher com a data da transferência do empregado para o empregador declarante.</xs:documentation>
-                                                                                                <xs:documentation>Validação: Deve ser posterior à data de admissão do trabalhador e igual ou anterior ao ano do óbito, se existente.</xs:documentation>
+                                                                                                <xs:documentation>Validação: Deve ser posterior à data de admissão do trabalhador e igual ou anterior à data do óbito, se existente (se não for possível obter a data do óbito, deve ser igual ou anterior ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta).</xs:documentation>
                                                                                             </xs:annotation>
                                                                                         </xs:element>
                                                                                     </xs:sequence>
@@ -556,7 +568,7 @@
                                                                             <xs:element name="infoDeslig" minOccurs="0">
                                                                                 <xs:annotation>
                                                                                     <xs:documentation>Informações do desligamento.</xs:documentation>
-                                                                                    <xs:documentation>CONDICAO_GRUPO: O (se {infoContr/tpContr}(2500_ideTrab_infoContr_tpContr) for diferente [8]); OC (nos demais casos)</xs:documentation>
+                                                                                    <xs:documentation>CONDICAO_GRUPO: O (se {infoContr/tpContr}(2500_ideTrab_infoContr_tpContr) for diferente de [8]); OC (nos demais casos)</xs:documentation>
                                                                                 </xs:annotation>
                                                                                 <xs:complexType>
                                                                                     <xs:sequence>
@@ -564,6 +576,9 @@
                                                                                             <xs:annotation>
                                                                                                 <xs:documentation>Preencher com a data de desligamento do vínculo (último dia trabalhado).</xs:documentation>
                                                                                                 <xs:documentation>Validação: Deve ser igual ou posterior a {dtAdm}(../dtAdm) e não superior à data atual (data do envio do evento) acrescida de 10 dias corridos.</xs:documentation>
+                                                                                                <xs:documentation>Se {mtvDeslig}(./mtvDeslig) = [10]:</xs:documentation>
+                                                                                                <xs:documentation>a) Caso a situação no cadastro do CPF na RFB seja diferente de "Titular Falecido", retornar erro até o 7º (sétimo) dia de {dtDeslig}(./dtDeslig) e retornar alerta a partir do 8º (oitavo) dia de {dtDeslig}(./dtDeslig);</xs:documentation>
+                                                                                                <xs:documentation>b) Caso a situação no cadastro do CPF na RFB seja igual a "Titular Falecido", {dtDeslig}(./dtDeslig) deve ser igual à data de óbito no cadastro do CPF da RFB (se não for possível obter a data do óbito, o ano de {dtDeslig}(./dtDeslig) deve ser igual ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta).</xs:documentation>
                                                                                             </xs:annotation>
                                                                                         </xs:element>
                                                                                         <xs:element name="mtvDeslig">
@@ -609,6 +624,9 @@
                                                                                 <xs:annotation>
                                                                                     <xs:documentation>Data do término.</xs:documentation>
                                                                                     <xs:documentation>Validação: Deve ser igual ou posterior a {dtInicio}(../../dtInicio) e igual ou anterior à data atual acrescida de 10 (dez) dias.</xs:documentation>
+                                                                                    <xs:documentation>Se {mtvDesligTSV}(./mtvDesligTSV) = [05]:</xs:documentation>
+                                                                                    <xs:documentation>a) Caso a situação no cadastro do CPF na RFB seja diferente de "Titular Falecido", retornar erro até o 7º (sétimo) dia de {dtTerm}(./dtTerm) e retornar alerta a partir do 8º (oitavo) dia de {dtTerm}(./dtTerm);</xs:documentation>
+                                                                                    <xs:documentation>b) Caso a situação no cadastro do CPF na RFB seja igual a "Titular Falecido", {dtTerm}(./dtTerm) deve ser igual à data de óbito no cadastro do CPF da RFB (se não for possível obter a data do óbito, o ano de {dtTerm}(./dtTerm) deve ser igual ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta).</xs:documentation>
                                                                                 </xs:annotation>
                                                                             </xs:element>
                                                                             <xs:element name="mtvDesligTSV" minOccurs="0">
@@ -675,8 +693,10 @@
                                                                     <xs:annotation>
                                                                         <xs:documentation>Preencher com o código da categoria do trabalhador.</xs:documentation>
                                                                         <xs:documentation>Validação: Deve ser um código válido e existente na Tabela 01 e obedecer ao que segue:</xs:documentation>
-                                                                        <xs:documentation>a) Se {}(../indContr) = [S], deve ser um código de categoria diferente daquele presente no contrato original;</xs:documentation>
-                                                                        <xs:documentation>b) Se {}(../indContr) = [N], deve ser um código de categoria diferente daquele informado em {infoContr/codCateg}(../codCateg).</xs:documentation>
+                                                                        <xs:documentation>a) Se {indContr}(../indContr) = [S] e {indCateg}(../indCateg) = [S], deve ser um código de categoria diferente daquele presente no contrato original;</xs:documentation>
+                                                                        <xs:documentation>b) Se {indContr}(../indContr) = [N] e {indCateg}(../indCateg) = [S], deve ser um código de categoria diferente daquele informado em {infoContr/codCateg}(../codCateg);</xs:documentation>
+                                                                        <xs:documentation>c) Se {indContr}(../indContr) = [S] e {indCateg}(../indCateg) = [N], deve ser o mesmo código de categoria daquele presente no contrato original;</xs:documentation>
+                                                                        <xs:documentation>d) Se {indContr}(../indContr) = [N] e {indCateg}(../indCateg) = [N], deve ser o mesmo código de categoria daquele informado em {infoContr/codCateg}(../codCateg).</xs:documentation>
                                                                     </xs:annotation>
                                                                 </xs:element>
                                                                 <xs:element name="natAtividade" minOccurs="0" type="TS_natAtividade">
@@ -685,8 +705,10 @@
                                                                         <xs:documentation>Validação: Não informar se {mudCategAtiv/codCateg}(./codCateg) = [721, 722, 771, 901] e observar o que segue:</xs:documentation>
                                                                         <xs:documentation>a) Se {mudCategAtiv/codCateg}(./codCateg) = [104], não pode ser preenchido com [2];</xs:documentation>
                                                                         <xs:documentation>b) Se {mudCategAtiv/codCateg}(./codCateg) = [102], não pode ser preenchido com [1];</xs:documentation>
-                                                                        <xs:documentation>c) Se {}(../indContr) = [S], deve ser uma natureza de atividade diferente daquela presente no contrato original;</xs:documentation>
-                                                                        <xs:documentation>d) Se {}(../indContr) = [N], deve ser uma natureza de atividade diferente daquela informada em {infoContr/natAtividade}(../infoCompl_natAtividade).</xs:documentation>
+                                                                        <xs:documentation>c) Se {indContr}(../indContr) = [S] e {indNatAtiv}(../indNatAtiv) = [S], deve ser uma natureza de atividade diferente daquela presente no contrato original;</xs:documentation>
+                                                                        <xs:documentation>d) Se {indContr}(../indContr) = [N] e {indNatAtiv}(../indNatAtiv) = [S], deve ser uma natureza de atividade diferente daquela informada em {infoContr/natAtividade}(../infoCompl_natAtividade);</xs:documentation>
+                                                                        <xs:documentation>e) Se {indContr}(../indContr) = [S] e {indNatAtiv}(../indNatAtiv) = [N], deve ser a mesma natureza de atividade daquela presente no contrato original;</xs:documentation>
+                                                                        <xs:documentation>f) Se {indContr}(../indContr) = [N] e {indNatAtiv}(../indNatAtiv) = [N], deve ser a mesma natureza de atividade daquela informada em {infoContr/natAtividade}(../infoCompl_natAtividade).</xs:documentation>
                                                                     </xs:annotation>
                                                                 </xs:element>
                                                                 <xs:element name="dtMudCategAtiv" type="xs:date">
@@ -771,7 +793,7 @@
                                                                             <xs:element name="compFim" type="TS_periodo_mensal">
                                                                                 <xs:annotation>
                                                                                     <xs:documentation>Competência final a que se refere o processo ou conciliação, no formato AAAA-MM.</xs:documentation>
-                                                                                    <xs:documentation>Validação: Deve ser igual ou posterior a {compIni}(./compIni) e igual ou anterior ao mês/ano de {dtSent}(2500_infoProcesso_dadosCompl_infoProcJud_dtSent) ou {dtCCP}(2500_infoProcesso_dadosCompl_infoCCP_dtCCP).</xs:documentation>
+                                                                                    <xs:documentation>Validação: Deve ser igual ou posterior a {compIni}(./compIni) e igual ou anterior ao mês/ano da data atual. Se for posterior ao mês/ano de {dtSent}(2500_infoProcesso_dadosCompl_infoProcJud_dtSent) ou {dtCCP}(2500_infoProcesso_dadosCompl_infoCCP_dtCCP), retornar alerta.</xs:documentation>
                                                                                 </xs:annotation>
                                                                             </xs:element>
                                                                             <xs:element name="indReperc">
@@ -907,7 +929,8 @@
                                                                                                     <xs:element name="vrBcFGTSSefip" type="TS_valorMonetario_positivo" minOccurs="0">
                                                                                                         <xs:annotation>
                                                                                                             <xs:documentation>Valor da base de cálculo de FGTS declarada apenas em SEFIP (não informada no eSocial) e ainda não recolhida.</xs:documentation>
-                                                                                                            <xs:documentation>Validação: Deve ser maior que 0 (zero).</xs:documentation>
+                                                                                                            <xs:documentation>Validação: Somente pode ser informado se {perRef}(../perRef) for anterior ao início do FGTS Digital.</xs:documentation>
+                                                                                                            <xs:documentation>Deve ser maior que 0 (zero).</xs:documentation>
                                                                                                         </xs:annotation>
                                                                                                     </xs:element>
                                                                                                     <xs:element name="vrBcFGTSDecAnt" type="TS_valorMonetario_positivo" minOccurs="0">
@@ -947,7 +970,7 @@
                                                                                             <xs:annotation>
                                                                                                 <xs:documentation>Informações relativas ao trabalho intermitente.</xs:documentation>
                                                                                                 <xs:documentation>CHAVE_GRUPO: {dia}</xs:documentation>
-                                                                                                <xs:documentation>CONDICAO_GRUPO: O ((se {infoContr/indContr}(2500_ideTrab_infoContr_indContr) = [N] e {infoContr/codCateg}(2500_ideTrab_infoContr_codCateg) = [111]) ou (se {infoContr/indContr}(2500_ideTrab_infoContr_indContr) = [S] e o código de categoria no RET for igual a [111])); N (nos demais casos)</xs:documentation>
+                                                                                                <xs:documentation>CONDICAO_GRUPO: O ((se ({infoContr/codCateg}(2500_ideTrab_infoContr_codCateg) ou o código de categoria no RET for diferente de [111]) e {mudCategAtiv/codCateg}(2500_ideTrab_infoContr_mudCategAtiv_codCateg) = [111] e mês/ano de {dtMudCategAtiv}(2500_ideTrab_infoContr_mudCategAtiv_dtMudCategAtiv) &lt;= {perRef}(../perRef)) OU (se ({infoContr/codCateg}(2500_ideTrab_infoContr_codCateg) ou o código de categoria no RET for igual a [111]) e {mudCategAtiv/codCateg}(2500_ideTrab_infoContr_mudCategAtiv_codCateg) não for informado ou for igual a [111])); N (nos demais casos)</xs:documentation>
                                                                                             </xs:annotation>
                                                                                         </xs:element>
                                                                                     </xs:sequence>

--- a/schemes/v_S_01_03_00/evtRemun.xsd
+++ b/schemes/v_S_01_03_00/evtRemun.xsd
@@ -39,8 +39,10 @@
                         <xs:documentation>REGRA:REGRA_RUBRICA_COMPATIVEL_RESC</xs:documentation>
                         <xs:documentation>REGRA:REGRA_RUBRICA_ECONSIGNADO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_TSV_ATIVO_NA_DTEVENTO</xs:documentation>
+                        <xs:documentation>REGRA:REGRA_VALIDA_CODINCCP_EXC_SEGURADO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_VALIDA_EMPREGADOR</xs:documentation>
                         <xs:documentation>REGRA:REGRA_VALIDA_PERIODO_APURACAO</xs:documentation>
+                        <xs:documentation>REGRA:REGRA_VALIDA_REMUN_CONTRATO</xs:documentation>
                     </xs:annotation>
                     <xs:complexType>
                         <xs:sequence>
@@ -93,7 +95,7 @@
                                             <xs:annotation>
                                                 <xs:documentation>Informações complementares de identificação do trabalhador</xs:documentation>
                                                 <xs:documentation>DESCRICAO_COMPLETA:Grupo preenchido quando o evento de remuneração se referir a trabalhador cuja categoria não está sujeita ao evento de admissão ou ao evento TSVE - Início, bem como para informar remuneração devida pela empresa sucessora a empregado desligado ainda na sucedida. No caso das categorias em que o envio do evento TSVE - Início for opcional, o preenchimento do grupo somente é exigido se não houver o respectivo evento. As informações complementares são necessárias para correta identificação do trabalhador.</xs:documentation>
-                                                <xs:documentation>CONDICAO_GRUPO: O ((se o trabalhador não tiver nenhum cadastro no RET) OU (se {remunSuc}(1200_dmDev_infoPerAnt_ideADC_remunSuc) = [S])); N (se o trabalhador tiver cadastro ativo no RET); OC (nos demais casos)</xs:documentation>
+                                                <xs:documentation>CONDICAO_GRUPO: O ((se o trabalhador não tiver nenhum cadastro no RET) OU (se {remunSuc}(1200_dmDev_infoPerAnt_ideADC_remunSuc) = [S])); N (se o trabalhador tiver cadastro ativo no RET em pelo menos um dia de {perApur}(1200_ideEvento_perApur)); OC (nos demais casos)</xs:documentation>
                                             </xs:annotation>
                                             <xs:complexType>
                                                 <xs:sequence>
@@ -111,7 +113,7 @@
                                                                     <xs:annotation>
                                                                         <xs:documentation>Informar o número de inscrição do empregador anterior, de acordo com o tipo de inscrição indicado no campo {sucessaoVinc/tpInsc}(./tpInsc).</xs:documentation>
                                                                         <xs:documentation>Validação: Deve ser um número de inscrição válido e diferente da inscrição do declarante, considerando as particularidades aplicadas à informação de CNPJ de órgão público em S-1000.</xs:documentation>
-                                                                        <xs:documentation>Se {sucessaoVinc/tpInsc}(./tpInsc) = [1], deve possuir 14 (catorze) algarismos e ser diferente do CNPJ base do empregador (exceto se {ideEmpregador/nrInsc}(1200_ideEmpregador_nrInsc) tiver 14 (catorze) algarismos) e dos estabelecimentos informados através do evento S-1005.</xs:documentation>
+                                                                        <xs:documentation>Se {sucessaoVinc/tpInsc}(./tpInsc) = [1], deve possuir 14 (catorze) algarismos e ser diferente do CNPJ base do empregador (exceto se {ideEmpregador/nrInsc}(1200_ideEmpregador_nrInsc) tiver 14 (catorze) algarismos). Também deve ser diferente dos estabelecimentos informados através do evento S-1005, exceto se a natureza jurídica do declarante for Administração Pública (grupo [1]).</xs:documentation>
                                                                         <xs:documentation>Se {sucessaoVinc/tpInsc}(./tpInsc) = [2], deve possuir 11 (onze) algarismos.</xs:documentation>
                                                                     </xs:annotation>
                                                                 </xs:element>
@@ -153,6 +155,7 @@
                                         </xs:element>
                                         <xs:element name="codCateg" type="TS_codCateg" />
                                         <xs:element name="indRRA" minOccurs="0" type="TS_indRRA" />
+                                        <xs:element name="notAFT" minOccurs="0" type="TS_notAFT" />
                                         <xs:element name="infoRRA" minOccurs="0" type="T_infoRRA" />
                                         <xs:element name="infoPerApur" minOccurs="0">
                                             <xs:annotation>
@@ -221,7 +224,7 @@
                                                 <xs:documentation>c) bases de cálculo para efeitos de apuração de FGTS resultantes de conversão de licença saúde em acidente de trabalho;</xs:documentation>
                                                 <xs:documentation>d) verbas de natureza salarial ou não salarial devidas após o desligamento.</xs:documentation>
                                                 <xs:documentation>OBS.: As informações previstas acima podem se referir ao período de apuração definido em {perApur}(1200_ideEvento_perApur) ou a períodos anteriores a {perApur}(1200_ideEvento_perApur).</xs:documentation>
-                                                <xs:documentation>CONDICAO_GRUPO: N (se {indApuracao}(1200_ideEvento_indApuracao) = [2] ou {codCateg}(1200_dmDev_codCateg) for diferente de [1XX, 2XX, 3XX, 4XX, 721, 722, 771, 901, 902]); O (se não existir o grupo {infoPerApur}(1200_dmDev_infoPerApur) e {indApuracao}(1200_ideEvento_indApuracao) = [1]); OC (nos demais casos)</xs:documentation>
+                                                <xs:documentation>CONDICAO_GRUPO: N (se {indApuracao}(1200_ideEvento_indApuracao) = [2] ou {}(1200_dmDev_notAFT) for informado ou {codCateg}(1200_dmDev_codCateg) for diferente de [1XX, 2XX, 3XX, 4XX, 721, 722, 771, 901, 902]); O (se não existir o grupo {infoPerApur}(1200_dmDev_infoPerApur) e {indApuracao}(1200_ideEvento_indApuracao) = [1]); OC (nos demais casos)</xs:documentation>
                                             </xs:annotation>
                                             <xs:complexType>
                                                 <xs:sequence>
@@ -325,7 +328,7 @@
                                             <xs:annotation>
                                                 <xs:documentation>Informações complementares contratuais do trabalhador</xs:documentation>
                                                 <xs:documentation>DESCRICAO_COMPLETA:Grupo preenchido exclusivamente quando o evento de remuneração se referir a trabalhador cuja categoria não estiver obrigada ao evento de início de TSVE e se não houver evento S-2300 correspondente.</xs:documentation>
-                                                <xs:documentation>CONDICAO_GRUPO: O ((se {codCateg}(1200_dmDev_codCateg) = [2XX, 304, 305, 4XX, 5XX, 7XX, 902]) E (se para o trabalhador não houver evento S-2300 ativo) E (se não for informado {remunPerApur/matricula}(1200_dmDev_infoPerApur_ideEstabLot_remunPerApur_matricula) ou {remunPerAnt/matricula}(1200_dmDev_infoPerAnt_ideADC_idePeriodo_ideEstabLot_remunPerAnt_matricula))); OC ((se {codCateg}(1200_dmDev_codCateg) = [901, 903, 904]) E (se para o trabalhador não houver evento S-2300 ativo) E (se não for informado {remunPerApur/matricula}(1200_dmDev_infoPerApur_ideEstabLot_remunPerApur_matricula) ou {remunPerAnt/matricula}(1200_dmDev_infoPerAnt_ideADC_idePeriodo_ideEstabLot_remunPerAnt_matricula))); N (nos demais casos)</xs:documentation>
+                                                <xs:documentation>CONDICAO_GRUPO: O ((se {codCateg}(1200_dmDev_codCateg) = [2XX, 304, 305, 4XX, 5XX, 7XX, 902]) E (se para o trabalhador não houver evento S-2300 ativo em pelo menos um dia de {perApur}(1200_ideEvento_perApur)) E (se não for informado {remunPerApur/matricula}(1200_dmDev_infoPerApur_ideEstabLot_remunPerApur_matricula) ou {remunPerAnt/matricula}(1200_dmDev_infoPerAnt_ideADC_idePeriodo_ideEstabLot_remunPerAnt_matricula))); OC ((se {codCateg}(1200_dmDev_codCateg) = [901, 903, 904]) E (se para o trabalhador não houver evento S-2300 ativo em pelo menos um dia de {perApur}(1200_ideEvento_perApur)) E (se não for informado {remunPerApur/matricula}(1200_dmDev_infoPerApur_ideEstabLot_remunPerApur_matricula) ou {remunPerAnt/matricula}(1200_dmDev_infoPerAnt_ideADC_idePeriodo_ideEstabLot_remunPerAnt_matricula))); N (nos demais casos)</xs:documentation>
                                             </xs:annotation>
                                             <xs:complexType>
                                                 <xs:sequence>

--- a/schemes/v_S_01_03_00/evtRmnRPPS.xsd
+++ b/schemes/v_S_01_03_00/evtRmnRPPS.xsd
@@ -28,6 +28,7 @@
                         <xs:documentation>REGRA:REGRA_REMUN_PERMITE_EXCLUSAO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_REMUN_TRAB_EXISTENTE_RET</xs:documentation>
                         <xs:documentation>REGRA:REGRA_REMUN_VALIDA_INFO_COMPLEMENTAR</xs:documentation>
+                        <xs:documentation>REGRA:REGRA_RUBRICA_ECONSIGNADO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_TSV_ATIVO_NA_DTEVENTO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_VALIDA_EMPREGADOR</xs:documentation>
                         <xs:documentation>REGRA:REGRA_VALIDA_PERIODO_APURACAO</xs:documentation>

--- a/schemes/v_S_01_03_00/evtTSVInicio.xsd
+++ b/schemes/v_S_01_03_00/evtTSVInicio.xsd
@@ -178,7 +178,7 @@
                                                 <xs:documentation>f) Para o servidor público exercente de cargo eletivo, a data de início do mandato;</xs:documentation>
                                                 <xs:documentation>g) Para os demais trabalhadores, a data de início das atividades.</xs:documentation>
                                                 <xs:documentation>Validação: Devem ser observadas as seguintes regras:</xs:documentation>
-                                                <xs:documentation>a) Deve ser posterior à data de nascimento do trabalhador, não pode ser posterior a 30 (trinta) dias da data atual e deve ser igual ou anterior ao ano do óbito, se existente;</xs:documentation>
+                                                <xs:documentation>a) Deve ser posterior à data de nascimento do trabalhador, não pode ser posterior a 30 (trinta) dias da data atual e deve ser igual ou anterior à data do óbito, se existente (se não for possível obter a data do óbito, deve ser igual ou anterior ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta);</xs:documentation>
                                                 <xs:documentation>b) Se {cadIni}(./cadIni) = [S], deve ser anterior à data de início da obrigatoriedade dos eventos não periódicos para o empregador no eSocial;</xs:documentation>
                                                 <xs:documentation>c) Se {cadIni}(./cadIni) = [N], deve ser igual ou posterior à data de início da obrigatoriedade dos eventos não periódicos para o empregador no eSocial.</xs:documentation>
                                             </xs:annotation>
@@ -483,7 +483,8 @@
                                                             <xs:documentation>Preencher com a data do término.</xs:documentation>
                                                             <xs:documentation>Validação: Devem ser observadas as seguintes regras:</xs:documentation>
                                                             <xs:documentation>a) Deve ser igual ou posterior à data de início do TSVE;</xs:documentation>
-                                                            <xs:documentation>b) Deve ser anterior à data de início da obrigatoriedade dos eventos não periódicos para o empregador.</xs:documentation>
+                                                            <xs:documentation>b) Caso a situação no cadastro do CPF na RFB seja igual a "Titular Falecido", {dtTerm}(./dtTerm) deve ser igual ou anterior à data de óbito no cadastro do CPF da RFB (se não for possível obter a data do óbito, o ano de {dtTerm}(./dtTerm) deve ser igual ou anterior ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta);</xs:documentation>
+                                                            <xs:documentation>c) Deve ser anterior à data de início da obrigatoriedade dos eventos não periódicos para o empregador.</xs:documentation>
                                                         </xs:annotation>
                                                     </xs:element>
                                                 </xs:sequence>

--- a/schemes/v_S_01_03_00/evtTSVTermino.xsd
+++ b/schemes/v_S_01_03_00/evtTSVTermino.xsd
@@ -27,6 +27,7 @@
                         <xs:documentation>REGRA:REGRA_RUBRICA_COMPATIVEL_CATEGORIA</xs:documentation>
                         <xs:documentation>REGRA:REGRA_RUBRICA_ECONSIGNADO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_TSV_ATIVO_NA_DTEVENTO</xs:documentation>
+                        <xs:documentation>REGRA:REGRA_VALIDA_CODINCCP_EXC_SEGURADO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_VALIDA_EMPREGADOR</xs:documentation>
                         <xs:documentation>REGRA:REGRA_VALIDA_PERIODO_APURACAO</xs:documentation>
                     </xs:annotation>
@@ -46,6 +47,9 @@
                                             <xs:annotation>
                                                 <xs:documentation>Data do término.</xs:documentation>
                                                 <xs:documentation>Validação: Deve ser uma data igual ou anterior à data atual acrescida de 10 (dez) dias.</xs:documentation>
+                                                <xs:documentation>Se {mtvDesligTSV}(./mtvDesligTSV) = [05]:</xs:documentation>
+                                                <xs:documentation>a) Caso a situação no cadastro do CPF na RFB seja diferente de "Titular Falecido", retornar erro até o 7º (sétimo) dia de {dtTerm}(./dtTerm) e retornar alerta a partir do 8º (oitavo) dia de {dtTerm}(./dtTerm);</xs:documentation>
+                                                <xs:documentation>b) Caso a situação no cadastro do CPF na RFB seja igual a "Titular Falecido", {dtTerm}(./dtTerm) deve ser igual à data de óbito no cadastro do CPF da RFB (se não for possível obter a data do óbito, o ano de {dtTerm}(./dtTerm) deve ser igual ao ano do óbito; se não for possível obter a data e o ano do óbito, o evento deve ser recebido mediante alerta).</xs:documentation>
                                             </xs:annotation>
                                         </xs:element>
                                         <xs:element name="mtvDesligTSV" minOccurs="0">
@@ -160,6 +164,14 @@
                                                                         <xs:documentation>Somente preencher este campo se for um demonstrativo de RRA.</xs:documentation>
                                                                     </xs:annotation>
                                                                 </xs:element>
+                                                                <xs:element name="notAFT" minOccurs="0" type="TS_notAFT">
+                                                                    <xs:annotation>
+                                                                        <xs:documentation>Número da notificação de FGTS que deu origem à confissão.</xs:documentation>
+                                                                        <xs:documentation>Validação: Se o campo for preenchido:</xs:documentation>
+                                                                        <xs:documentation>a) O mês/ano de {}(2399_infoTSVTermino_dtTerm) deve ser igual ou posterior ao início do FGTS Digital;</xs:documentation>
+                                                                        <xs:documentation>b) Devem ser informados apenas caracteres alfanuméricos, com 9 (nove) posições.</xs:documentation>
+                                                                    </xs:annotation>
+                                                                </xs:element>
                                                                 <xs:element name="infoRRA" minOccurs="0" type="T_infoRRA" />
                                                                 <xs:element name="ideEstabLot" maxOccurs="99">
                                                                     <xs:annotation>
@@ -202,11 +214,33 @@
                                                                                                 <xs:documentation>Validação: Informação obrigatória e exclusiva se mês/ano de {dtTerm}(2399_infoTSVTermino_dtTerm) >= [2021-07].</xs:documentation>
                                                                                             </xs:annotation>
                                                                                         </xs:element>
-                                                                                        <xs:element name="descFolha" minOccurs="0" type="T_descFolha" />
+                                                                                        <xs:element name="descFolha" minOccurs="0">
+                                                                                            <xs:annotation>
+                                                                                                <xs:documentation>Informações de desconto do empréstimo em folha.</xs:documentation>
+                                                                                                <xs:documentation>CONDICAO_GRUPO: O (se {}(1010_infoRubrica_inclusao_dadosRubrica_natRubr) em S-1010 = [9253]); N (nos demais casos)</xs:documentation>
+                                                                                            </xs:annotation>
+                                                                                            <xs:complexType>
+                                                                                                <xs:sequence>
+                                                                                                    <xs:element name="tpDesc" type="TS_tpDesc" />
+                                                                                                    <xs:element name="instFinanc" type="TS_instFinanc">
+                                                                                                        <xs:annotation>
+                                                                                                            <xs:documentation>Código Bancário de Consignado concedente do empréstimo.</xs:documentation>
+                                                                                                            <xs:documentation>Validação: Deve ser um código válido, conforme Tabela  37 do eSocial Tabelas.</xs:documentation>
+                                                                                                        </xs:annotation>
+                                                                                                    </xs:element>    
+                                                                                                    <xs:element name="nrDoc" type="TS_nrDoc" />
+                                                                                                    <xs:element name="observacao" minOccurs="0" type="TS_observacao">
+                                                                                                        <xs:annotation>
+                                                                                                            <xs:documentation>Outras informações do desconto.</xs:documentation>
+                                                                                                        </xs:annotation>
+                                                                                                    </xs:element>
+                                                                                                </xs:sequence>
+                                                                                            </xs:complexType>
+                                                                                        </xs:element>
                                                                                     </xs:sequence>
                                                                                 </xs:complexType>
                                                                             </xs:element>
-                                                                            <xs:element name="infoSimples" minOccurs="0" type="T_infoSimples" />
+                                                                            <xs:element name="infoSimples" minOccurs="0" type="T_infoSimples_S-2399" />
                                                                         </xs:sequence>
                                                                     </xs:complexType>
                                                                 </xs:element>

--- a/schemes/v_S_01_03_00/evtTabRubrica.xsd
+++ b/schemes/v_S_01_03_00/evtTabRubrica.xsd
@@ -20,6 +20,7 @@
                         <xs:documentation>REGRA:REGRA_TABGERAL_INCLUSAO_PERIODO_CONFLITANTE</xs:documentation>
                         <xs:documentation>REGRA:REGRA_TABRUBR_INCLUSAO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_TAB_PERMITE_EXCLUSAO</xs:documentation>
+                        <xs:documentation>REGRA:REGRA_VALIDA_CODINCCP_EXC_SEGURADO</xs:documentation>
                         <xs:documentation>REGRA:REGRA_VALIDA_DT_FUTURA</xs:documentation>
                     </xs:annotation>
                     <xs:complexType>
@@ -117,18 +118,7 @@
                     <xs:documentation>Informar a descrição (nome) da rubrica no sistema de folha de pagamento da empresa.</xs:documentation>
                 </xs:annotation>
             </xs:element>
-            <xs:element name="natRubr">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Informar o código de classificação da rubrica.</xs:documentation>
-                        <xs:documentation>Validação: Deve ser um código válido e existente na Tabela 03.</xs:documentation>
-                        <xs:documentation>Para utilização de código [9253], é necessário que {iniValid}(1010_infoRubrica_inclusao_ideRubrica_iniValid) seja igual ou posterior ao mês de início do eConsignado no eSocial.</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:integer">
-                        <xs:pattern value="\d{4}" />
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
+            <xs:element name="natRubr" type="TS_natRubr" />
             <xs:element name="tpRubr">
                 <xs:simpleType>
                     <xs:annotation>

--- a/schemes/v_S_01_03_00/tipos.xsd
+++ b/schemes/v_S_01_03_00/tipos.xsd
@@ -276,16 +276,7 @@
         </xs:annotation>
         <xs:sequence>
             <xs:element name="tpInsc" type="TS_tpInsc_1" />
-            <xs:element name="nrInsc">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Informar o número de inscrição do contribuinte de acordo com o tipo de inscrição indicado no campo {ideEmpregador/tpInsc}(./tpInsc) e conforme informado em S-1000.</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:string">
-                        <xs:pattern value="\d{8}|\d{14}" />
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
+            <xs:element name="nrInsc" type="TS_nrInsc_8_14" />
         </xs:sequence>
     </xs:complexType>
 
@@ -346,6 +337,7 @@
             </xs:element>
         </xs:sequence>
     </xs:complexType>
+
     <!-- Grupo {infoRRA} -->
 
     <xs:complexType name="T_infoRRA">
@@ -419,6 +411,25 @@
                         </xs:element>
                     </xs:sequence>
                 </xs:complexType>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <!-- Grupo {descFolha} (S-1200, S-1202 e S-1207) -->
+
+    <xs:complexType name="T_descFolha">
+        <xs:annotation>
+            <xs:documentation>Informações de desconto do empréstimo em folha.</xs:documentation>
+            <xs:documentation>CONDICAO_GRUPO: O (se {}(1010_infoRubrica_inclusao_dadosRubrica_natRubr) em S-1010 = [9253]); N (nos demais casos)</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="tpDesc" type="TS_tpDesc" />
+            <xs:element name="instFinanc" type="TS_instFinanc" />
+            <xs:element name="nrDoc" type="TS_nrDoc" />
+            <xs:element name="observacao" minOccurs="0" type="TS_observacao">
+                <xs:annotation>
+                    <xs:documentation>Outras informações do desconto.</xs:documentation>
+                </xs:annotation>
             </xs:element>
         </xs:sequence>
     </xs:complexType>
@@ -513,7 +524,6 @@
             </xs:element>
         </xs:sequence>
     </xs:complexType>
-
 
     <!-- Grupo {nascimento} -->
 
@@ -916,9 +926,24 @@
         </xs:sequence>
     </xs:complexType>
 
-    <!-- Grupo {infoMV} -->
+    <!-- Grupo {infoSimples} -->
 
-    <xs:complexType name="T_infoSimples">
+    <xs:complexType name="T_infoSimples_S-2299">
+        <xs:annotation>
+            <xs:documentation>Informação relativa a empresas do Simples</xs:documentation>
+            <xs:documentation>DESCRICAO_COMPLETA:Informação relativa a empresas enquadradas no regime de tributação Simples Nacional.</xs:documentation>
+            <xs:documentation>CONDICAO_GRUPO: O (se {classTrib}(1000_infoEmpregador_inclusao_infoCadastro_classTrib) em S-1000 = [03] no mês/ano de {dtDeslig}(2299_infoDeslig_dtDeslig)); N (nos demais casos)</xs:documentation>
+        </xs:annotation>
+        <xs:sequence>
+            <xs:element name="indSimples" type="TS_indSimples">
+                <xs:annotation>
+                    <xs:documentation>Indicador de contribuição substituída.</xs:documentation>
+                </xs:annotation>
+            </xs:element>
+        </xs:sequence>
+    </xs:complexType>
+
+    <xs:complexType name="T_infoSimples_S-2399">
         <xs:annotation>
             <xs:documentation>Informação relativa a empresas do Simples</xs:documentation>
             <xs:documentation>DESCRICAO_COMPLETA:Informação relativa a empresas enquadradas no regime de tributação Simples Nacional.</xs:documentation>
@@ -1184,59 +1209,6 @@
         </xs:sequence>
     </xs:complexType>
 
-    <!-- Grupo {descFolha} (S-1200, S-1202, S-1207, S-2299 e S-2399) -->
-
-    <xs:complexType name="T_descFolha">
-        <xs:annotation>
-            <xs:documentation>Informações de desconto do empréstimo em folha.</xs:documentation>
-            <xs:documentation>CONDICAO_GRUPO: O (se {}(1010_infoRubrica_inclusao_dadosRubrica_natRubr) em S-1010 = [9253]); N (nos demais casos)</xs:documentation>
-        </xs:annotation>
-        <xs:sequence>
-            <xs:element name="tpDesc">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Indicativo do tipo de desconto.</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:byte">
-                        <xs:enumeration value="1">
-                            <xs:annotation>
-                                <xs:documentation>eConsignado</xs:documentation>
-                            </xs:annotation>
-                        </xs:enumeration>
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="instFinanc">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Código da Instituição Financeira concedente do empréstimo.</xs:documentation>
-                        <xs:documentation>Validação: Deve ser um código válido, conforme tabela do Banco Central.</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:string">
-                        <xs:pattern value="\d{3}" />
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="nrDoc">
-                <xs:simpleType>
-                    <xs:annotation>
-                        <xs:documentation>Número do contrato referente ao empréstimo.</xs:documentation>
-                    </xs:annotation>
-                    <xs:restriction base="xs:string">
-                        <xs:minLength value="1" />
-                        <xs:maxLength value="15" />
-                        <xs:pattern value="[A-Za-z0-9][-_A-Za-z0-9/.//]{0,13}[A-Za-z0-9]" />
-                    </xs:restriction>
-                </xs:simpleType>
-            </xs:element>
-            <xs:element name="observacao" minOccurs="0" type="TS_observacao">
-                <xs:annotation>
-                    <xs:documentation>Outras informações do desconto.</xs:documentation>
-                </xs:annotation>
-            </xs:element>
-        </xs:sequence>
-    </xs:complexType>
-
     <!-- Campo {Id} -->
 
     <xs:simpleType name="TS_Id">
@@ -1246,7 +1218,7 @@
         </xs:annotation>
         <xs:restriction base="xs:ID">
             <xs:length value="36" />
-            <xs:pattern value="ID\d{34}" />
+            <xs:pattern value="ID\d{1}[A-Z0-9]{12}\d{21}" />
         </xs:restriction>
     </xs:simpleType>
 
@@ -1679,34 +1651,44 @@
 
     <xs:simpleType name="TS_nrInsc_8_11_14">
         <xs:restriction base="xs:string">
-            <xs:pattern value="\d{8}|\d{11}|\d{14}" />
+            <xs:pattern value="[A-Z0-9]{8}|\d{11}|[A-Z0-9]{12}\d{2}" />
         </xs:restriction>
     </xs:simpleType>
 
     <xs:simpleType name="TS_nrInsc_12_14">
         <xs:restriction base="xs:string">
-            <xs:pattern value="\d{12}|\d{14}" />
+            <xs:pattern value="\d{12}|[A-Z0-9]{12}\d{2}" />
         </xs:restriction>
     </xs:simpleType>
 
     <xs:simpleType name="TS_nrInsc_11_12_14">
         <xs:restriction base="xs:string">
-            <xs:pattern value="\d{11}|\d{12}|\d{14}" />
+            <xs:pattern value="\d{11}|\d{12}|[A-Z0-9]{12}\d{2}" />
         </xs:restriction>
     </xs:simpleType>
 
     <xs:simpleType name="TS_nrInsc_11_14">
         <xs:restriction base="xs:string">
-            <xs:pattern value="\d{11}|\d{14}" />
+            <xs:pattern value="\d{11}|[A-Z0-9]{12}\d{2}" />
         </xs:restriction>
     </xs:simpleType>
 
     <xs:simpleType name="TS_cnpj">
         <xs:restriction base="xs:string">
-            <xs:pattern value="\d{14}" />
+            <xs:length value="14" />
+            <xs:pattern value="[A-Z0-9]{12}\d{2}" />
         </xs:restriction>
     </xs:simpleType>
-    
+
+    <xs:simpleType name="TS_nrInsc_8_14">
+        <xs:annotation>
+            <xs:documentation>Informar o número de inscrição do contribuinte de acordo com o tipo de inscrição indicado no campo {ideEmpregador/tpInsc}(./tpInsc) e conforme informado em S-1000.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="[A-Z0-9]{8}|[A-Z0-9]{12}\d{2}" />
+        </xs:restriction>
+    </xs:simpleType>
+
     <!-- Campo {iniValid} -->
 
     <xs:simpleType name="TS_iniValid">
@@ -1967,6 +1949,18 @@
             <xs:minLength value="1" />
             <xs:maxLength value="8" />
             <xs:pattern value=".*[^\s].*" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- Campo {natRubr} -->
+
+    <xs:simpleType name="TS_natRubr">
+        <xs:annotation>
+            <xs:documentation>Informar o código de classificação da rubrica.</xs:documentation>
+            <xs:documentation>Validação: Deve ser um código válido e existente na Tabela 03.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:integer">
+            <xs:pattern value="\d{4}" />
         </xs:restriction>
     </xs:simpleType>
 
@@ -2397,6 +2391,21 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <!-- Campo {notAFT} -->
+
+    <xs:simpleType name="TS_notAFT">
+        <xs:annotation>
+            <xs:documentation>Número da notificação de FGTS que deu origem à confissão.</xs:documentation>
+            <xs:documentation>Validação: Se o campo for preenchido:</xs:documentation>
+            <xs:documentation>a) {}(1200_ideEvento_perApur) deve ser igual ou posterior ao início do FGTS Digital;</xs:documentation>
+            <xs:documentation>b) Devem ser informados apenas caracteres alfanuméricos, com 9 (nove) posições.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:length value="9" />
+            <xs:pattern value="[A-Za-z0-9]{9}" />
+        </xs:restriction>
+    </xs:simpleType>
+
     <!-- Campo {ideEstabLot/tpInsc} -->
 
     <xs:simpleType name="TS_tpInsc_EstabLot">
@@ -2451,7 +2460,7 @@
     <xs:simpleType name="TS_indSimples">
         <xs:annotation>
             <xs:documentation>Indicador de contribuição substituída.</xs:documentation>
-            <xs:documentation>Validação: O preenchimento do campo é obrigatório apenas no caso das empresas enquadradas no regime de tributação Simples Nacional, com tributação previdenciária substituída e não substituída ({classTrib}(1000_infoEmpregador_inclusao_infoCadastro_classTrib) em S-1000 = [03]). Para os demais empregadores, não deve ser informado.</xs:documentation>
+            <xs:documentation>Validação: O preenchimento do campo é obrigatório apenas no caso das empresas enquadradas no regime de tributação Simples Nacional, com tributação previdenciária substituída e não substituída em {perApur}(1200_ideEvento_perApur) ({classTrib}(1000_infoEmpregador_inclusao_infoCadastro_classTrib) em S-1000 = [03] em {perApur}(1200_ideEvento_perApur)). Para os demais empregadores, não deve ser informado.</xs:documentation>
         </xs:annotation>
         <xs:restriction base="xs:byte">
             <xs:enumeration value="1">
@@ -2526,6 +2535,49 @@
                     <xs:documentation>Situação especial de apuração de IR</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- Campo {tpDesc} -->
+
+    <xs:simpleType name="TS_tpDesc">
+        <xs:annotation>
+            <xs:documentation>Indicativo do tipo de desconto.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:byte">
+            <xs:enumeration value="1">
+                <xs:annotation>
+                    <xs:documentation>eConsignado</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- Campo {instFinanc} -->
+
+    <xs:simpleType name="TS_instFinanc">
+        <xs:annotation>
+            <xs:documentation>Código Bancário de Consignado concedente do empréstimo.</xs:documentation>
+            <xs:documentation>Validação: Deve ser um código válido, conforme Tabela  37 do eSocial Tabelas.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:pattern value="\d{3}" />
+        </xs:restriction>
+    </xs:simpleType>
+
+    <!-- Campo {nrDoc} -->
+
+    <xs:simpleType name="TS_nrDoc">
+        <xs:annotation>
+            <xs:documentation>Número do contrato referente ao empréstimo.</xs:documentation>
+            <xs:documentation>Validação: Deve obedecer ao que segue:</xs:documentation>
+            <xs:documentation>a) Somente são permitidos números, letras e os caracteres ".", "/", "-" e "_";</xs:documentation>
+            <xs:documentation>b) Os caracteres ".", "/", "-" e "_" não podem ser informados na primeira e na última posições.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:minLength value="2" />
+            <xs:maxLength value="15" />
+            <xs:pattern value="[A-Za-z0-9][-_A-Za-z0-9/.//]{0,13}[A-Za-z0-9]" />
         </xs:restriction>
     </xs:simpleType>
 
@@ -4044,6 +4096,117 @@
         </xs:restriction>
     </xs:simpleType>
 
+    <!-- Campo {tpDepInst} -->
+
+    <xs:simpleType name="TS_tpDepInst">
+        <xs:annotation>
+            <xs:documentation>Tipo de dependente do instituidor da pensão por morte.</xs:documentation>
+            <xs:documentation>Validação: Se o campo não for informado e {dtIniBeneficio}(2410_infoBenInicio_dtIniBeneficio) >= [2025-11-24], retornar alerta.</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="xs:string">
+            <xs:enumeration value="01">
+                <xs:annotation>
+                    <xs:documentation>Cônjuge</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="02">
+                <xs:annotation>
+                    <xs:documentation>Companheiro(a)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="03">
+                <xs:annotation>
+                    <xs:documentation>Filho(a) até 21 anos</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="04">
+                <xs:annotation>
+                    <xs:documentation>Enteado(a)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="05">
+                <xs:annotation>
+                    <xs:documentation>Ex-companheiro(a)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="06">
+                <xs:annotation>
+                    <xs:documentation>Irmão(a)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="07">
+                <xs:annotation>
+                    <xs:documentation>Neto(a)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="08">
+                <xs:annotation>
+                    <xs:documentation>Filha maior solteira</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="09">
+                <xs:annotation>
+                    <xs:documentation>Pais</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="10">
+                <xs:annotation>
+                    <xs:documentation>Menor sob guarda ou tutela</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="11">
+                <xs:annotation>
+                    <xs:documentation>Filho(a) maior inválido ou com deficiência</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="12">
+                <xs:annotation>
+                    <xs:documentation>Ex-cônjuge</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="13">
+                <xs:annotation>
+                    <xs:documentation>Avós</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="14">
+                <xs:annotation>
+                    <xs:documentation>Bisavós</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="15">
+                <xs:annotation>
+                    <xs:documentation>Bisneto(a)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="16">
+                <xs:annotation>
+                    <xs:documentation>Curatelado(a)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="17">
+                <xs:annotation>
+                    <xs:documentation>Designado(a)</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>            
+            <xs:enumeration value="99">
+                <xs:annotation>
+                    <xs:documentation>Agregados/Outros</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+        </xs:restriction>
+    </xs:simpleType>
+     
+    <!-- Campo {descrDepInst} -->
+
+    <xs:simpleType name="TS_descrDepInst">
+        <xs:annotation>
+            <xs:documentation>Informar a descrição da dependência do instituidor da pensão por morte.</xs:documentation>
+            <xs:documentation>Validação: Informação obrigatória e exclusiva se {tpDepInst}(./tpDepInst) = [99].</xs:documentation>
+        </xs:annotation>
+        <xs:restriction base="TS_texto_100" />
+    </xs:simpleType>
+
     <!-- Campo {origem} -->
 
     <xs:simpleType name="TS_origem">
@@ -4053,12 +4216,17 @@
         <xs:restriction base="xs:byte">
             <xs:enumeration value="1">
                 <xs:annotation>
-                    <xs:documentation>Processo judicial</xs:documentation>
+                    <xs:documentation>Processo judicial trabalhista</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
             <xs:enumeration value="2">
                 <xs:annotation>
                     <xs:documentation>Demanda submetida à CCP ou ao NINTER</xs:documentation>
+                </xs:annotation>
+            </xs:enumeration>
+            <xs:enumeration value="3">
+                <xs:annotation>
+                    <xs:documentation>Processo da Justiça Comum</xs:documentation>
                 </xs:annotation>
             </xs:enumeration>
         </xs:restriction>

--- a/src/Factories/Traits/TraitS1200.php
+++ b/src/Factories/Traits/TraitS1200.php
@@ -1863,6 +1863,12 @@ trait TraitS1200
                 $indrra,
                 false
             );
+            $this->dom->addChild(
+                $dmdev,
+                "notAFT",
+                $dm->notaft ?? null,
+                false
+            );
             if (!empty($dm->inforra) && $indrra === 'S') {
                 $inf = $dm->inforra;
                 $ifrra = $this->dom->createElement("infoRRA");

--- a/src/Factories/Traits/TraitS2299.php
+++ b/src/Factories/Traits/TraitS2299.php
@@ -1785,6 +1785,14 @@ trait TraitS2299
                     false
                 );
 
+                $this->dom->addChild(
+                    $dmDev,
+                    "notAFT",
+                    $dm->notaft ?? null,
+                    false
+                );
+
+
                 if (!empty($dm->infoperapur)) {
                     $infoPerApur = $this->dom->createElement("infoPerApur");
                     foreach ($dm->infoperapur->ideestablot as $isl) {

--- a/src/Factories/Traits/TraitS2399.php
+++ b/src/Factories/Traits/TraitS2399.php
@@ -582,6 +582,319 @@ trait TraitS2399
      */
     protected function toNodeS130()
     {
-        return $this->toNodeS110();
+        $ideEmpregador = $this->node->getElementsByTagName('ideEmpregador')->item(0);
+        $ideEvento = $this->dom->createElement("ideEvento");
+        $this->dom->addChild(
+            $ideEvento,
+            "indRetif",
+            $this->std->indretif,
+            true
+        );
+        $this->dom->addChild(
+            $ideEvento,
+            "nrRecibo",
+            ! empty($this->std->nrrecibo) ? $this->std->nrrecibo : null,
+            false
+        );
+        $this->dom->addChild(
+            $ideEvento,
+            "tpAmb",
+            $this->tpAmb,
+            true
+        );
+        $this->dom->addChild(
+            $ideEvento,
+            "procEmi",
+            $this->procEmi,
+            true
+        );
+        $this->dom->addChild(
+            $ideEvento,
+            "verProc",
+            $this->verProc,
+            true
+        );
+        $this->node->insertBefore($ideEvento, $ideEmpregador);
+
+        $ideTrabSemVinculo = $this->dom->createElement("ideTrabSemVinculo");
+        $this->dom->addChild(
+            $ideTrabSemVinculo,
+            "cpfTrab",
+            $this->std->cpftrab,
+            true
+        );
+        $this->dom->addChild(
+            $ideTrabSemVinculo,
+            "matricula",
+            !empty($this->std->matricula) ? $this->std->matricula : null,
+            false
+        );
+        $this->dom->addChild(
+            $ideTrabSemVinculo,
+            "codCateg",
+            !empty($this->std->codcateg) ? $this->std->codcateg : null,
+            false
+        );
+        $this->node->appendChild($ideTrabSemVinculo);
+
+        $infoTSVTermino = $this->dom->createElement("infoTSVTermino");
+        $this->dom->addChild(
+            $infoTSVTermino,
+            "dtTerm",
+            $this->std->dtterm,
+            true
+        );
+        $this->dom->addChild(
+            $infoTSVTermino,
+            "mtvDesligTSV",
+            !empty($this->std->mtvdesligtsv) ? $this->std->mtvdesligtsv : null,
+            false
+        );
+        $this->dom->addChild(
+            $infoTSVTermino,
+            "pensAlim",
+            !empty($this->std->pensalim) ? $this->std->pensalim : null,
+            false
+        );
+        $this->dom->addChild(
+            $infoTSVTermino,
+            "percAliment",
+            !empty($this->std->percaliment) ? $this->std->percaliment : null,
+            false
+        );
+        $this->dom->addChild(
+            $infoTSVTermino,
+            "vrAlim",
+            !empty($this->std->vralim) ? $this->std->vralim : null,
+            false
+        );
+        $this->dom->addChild(
+            $infoTSVTermino,
+            "nrProcTrab",
+            !empty($this->std->nrproctrab) ? $this->std->nrproctrab : null,
+            false
+        );
+        if (!empty($this->std->novocpf)) {
+            $mudancaCPF = $this->dom->createElement("mudancaCPF");
+            $this->dom->addChild(
+                $mudancaCPF,
+                "novoCPF",
+                $this->std->novocpf,
+                true
+            );
+            $infoTSVTermino->appendChild($mudancaCPF);
+        }
+
+        if (!empty($this->std->verbasresc)) {
+            $vr = $this->std->verbasresc;
+            $verbasResc = $this->dom->createElement("verbasResc");
+            foreach ($vr->dmdev as $dv) {
+                $dmDev = $this->dom->createElement("dmDev");
+                $this->dom->addChild(
+                    $dmDev,
+                    "ideDmDev",
+                    $dv->idedmdev,
+                    true
+                );
+                $this->dom->addChild(
+                    $dmDev,
+                    "indRRA",
+                    $dv->indrra ?? null,
+                    false
+                );
+                $this->dom->addChild(
+                    $dmDev,
+                    "notAFT",
+                    $dv->notaft ?? null,
+                    false
+                );
+                if (!empty($dv->inforra) && ($dv->indrra ?? null) === 'S') {
+                    $inf = $dv->inforra;
+                    $ifrra = $this->dom->createElement("infoRRA");
+                    $this->dom->addChild($ifrra, "tpProcRRA", $inf->tpprocrra, true);
+                    $this->dom->addChild($ifrra, "nrProcRRA", $inf->nrprocrra ?? null, false);
+                    $this->dom->addChild($ifrra, "descRRA", $inf->descrra, true);
+                    $this->dom->addChild($ifrra, "qtdMesesRRA", $inf->qtdmesesrra, true);
+                    if (!empty($inf->despprocjud)) {
+                        $dpj = $inf->despprocjud;
+                        $despProcJud = $this->dom->createElement("despProcJud");
+                        $this->dom->addChild($despProcJud, "vlrDespCustas", $dpj->vlrdespcustas, true);
+                        $this->dom->addChild($despProcJud, "vlrDespAdvogados", $dpj->vlrdespadvogados, true);
+                        $ifrra->appendChild($despProcJud);
+                    }
+                    if (!empty($inf->ideadv)) {
+                        foreach ($inf->ideadv as $idadv) {
+                            $adv = $this->dom->createElement("ideAdv");
+                            $this->dom->addChild($adv, "tpInsc", $idadv->tpinsc, true);
+                            $this->dom->addChild($adv, "nrInsc", $idadv->nrinsc, true);
+                            $ifrra->appendChild($adv);
+                        }
+                    }
+                    $dmDev->appendChild($ifrra);
+                }
+                foreach ($dv->ideestablot as $el) {
+                    $ideEstabLot = $this->dom->createElement("ideEstabLot");
+                    $this->dom->addChild(
+                        $ideEstabLot,
+                        "tpInsc",
+                        $el->tpinsc,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $ideEstabLot,
+                        "nrInsc",
+                        $el->nrinsc,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $ideEstabLot,
+                        "codLotacao",
+                        $el->codlotacao,
+                        true
+                    );
+                    foreach ($el->detverbas as $dever) {
+                        $detVerbas = $this->dom->createElement("detVerbas");
+                        $this->dom->addChild(
+                            $detVerbas,
+                            "codRubr",
+                            $dever->codrubr,
+                            true
+                        );
+                        $this->dom->addChild(
+                            $detVerbas,
+                            "ideTabRubr",
+                            $dever->idetabrubr,
+                            true
+                        );
+                        $this->dom->addChild(
+                            $detVerbas,
+                            "qtdRubr",
+                            !empty($dever->qtdrubr) ? $dever->qtdrubr : null,
+                            false
+                        );
+                        $this->dom->addChild(
+                            $detVerbas,
+                            "fatorRubr",
+                            !empty($dever->fatorrubr) ? $dever->fatorrubr : null,
+                            false
+                        );
+                        $this->dom->addChild(
+                            $detVerbas,
+                            "vrRubr",
+                            $dever->vrrubr,
+                            true
+                        );
+                        $this->dom->addChild(
+                            $detVerbas,
+                            "indApurIR",
+                            isset($dever->indapurir) ? $dever->indapurir : null,
+                            false
+                        );
+                        $ideEstabLot->appendChild($detVerbas);
+                    }
+
+                    if (!empty($el->infosimples)) {
+                        $infoSimples = $this->dom->createElement("infoSimples");
+                        $this->dom->addChild(
+                            $infoSimples,
+                            "indSimples",
+                            $el->infosimples->indsimples,
+                            true
+                        );
+                        $ideEstabLot->appendChild($infoSimples);
+                    }
+
+                    $dmDev->appendChild($ideEstabLot);
+                }
+
+                $verbasResc->appendChild($dmDev);
+            }
+
+            if (!empty($this->std->verbasresc->procjudtrab)) {
+                foreach ($this->std->verbasresc->procjudtrab as $pj) {
+                    $procJudTrab = $this->dom->createElement("procJudTrab");
+                    $this->dom->addChild(
+                        $procJudTrab,
+                        "tpTrib",
+                        $pj->tptrib,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $procJudTrab,
+                        "nrProcJud",
+                        $pj->nrprocjud,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $procJudTrab,
+                        "codSusp",
+                        !empty($pj->codsusp) ? $pj->codsusp : null,
+                        false
+                    );
+                    $verbasResc->appendChild($procJudTrab);
+                }
+            }
+            if (!empty($this->std->verbasresc->infomv)) {
+                $infoMV = $this->dom->createElement("infoMV");
+                $this->dom->addChild(
+                    $infoMV,
+                    "indMV",
+                    $this->std->verbasresc->infomv->indmv,
+                    true
+                );
+                foreach ($this->std->verbasresc->infomv->remunoutrempr as $roe) {
+                    $remunOutrEmpr = $this->dom->createElement("remunOutrEmpr");
+                    $this->dom->addChild(
+                        $remunOutrEmpr,
+                        "tpInsc",
+                        $roe->tpinsc,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $remunOutrEmpr,
+                        "nrInsc",
+                        $roe->nrinsc,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $remunOutrEmpr,
+                        "codCateg",
+                        $roe->codcateg,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $remunOutrEmpr,
+                        "vlrRemunOE",
+                        $roe->vlrremunoe,
+                        true
+                    );
+                    $infoMV->appendChild($remunOutrEmpr);
+                }
+                $verbasResc->appendChild($infoMV);
+            }
+            $infoTSVTermino->appendChild($verbasResc);
+        }
+
+        if (!empty($this->std->remunaposterm)) {
+            $remun = $this->std->remunaposterm;
+            $rat = $this->dom->createElement("remunAposTerm");
+            $this->dom->addChild(
+                $rat,
+                "indRemun",
+                $remun->indremun ?? null,
+                false
+            );
+            $this->dom->addChild(
+                $rat,
+                "dtFimRemun",
+                $remun->dtfimremun,
+                true
+            );
+            $infoTSVTermino->appendChild($rat);
+        }
+
+        $this->node->appendChild($infoTSVTermino);
+        $this->eSocial->appendChild($this->node);
+        $this->sign();
     }
 }

--- a/src/Factories/Traits/TraitS2410.php
+++ b/src/Factories/Traits/TraitS2410.php
@@ -395,6 +395,18 @@ trait TraitS2410
                     $this->std->infopenmorte->instpenmorte->dtinst,
                     true
                 );
+                $this->dom->addChild(
+                    $instPenMorte,
+                    "tpDepInst",
+                    $this->std->infopenmorte->instpenmorte->tpdepinst ?? null,
+                    false
+                );
+                $this->dom->addChild(
+                    $instPenMorte,
+                    "descrDepInst",
+                    $this->std->infopenmorte->instpenmorte->descrdepinst ?? null,
+                    false
+                );
                 $infoPenMorte->appendChild($instPenMorte);
             }
             $dadosBeneficio->appendChild($infoPenMorte);

--- a/src/Factories/Traits/TraitS2416.php
+++ b/src/Factories/Traits/TraitS2416.php
@@ -151,6 +151,136 @@ trait TraitS2416
      */
     protected function toNodeS130()
     {
-        return $this->toNodeS100();
+        $ideEmpregador = $this->node->getElementsByTagName('ideEmpregador')->item(0);
+        $ideEvento = $this->dom->createElement("ideEvento");
+        $this->dom->addChild(
+            $ideEvento,
+            "indRetif",
+            $this->std->indretif,
+            true
+        );
+        if ($this->std->indretif == 2) {
+            $this->dom->addChild(
+                $ideEvento,
+                "nrRecibo",
+                $this->std->nrrecibo,
+                true
+            );
+        }
+        $this->dom->addChild(
+            $ideEvento,
+            "tpAmb",
+            $this->tpAmb,
+            true
+        );
+        $this->dom->addChild(
+            $ideEvento,
+            "procEmi",
+            $this->procEmi,
+            true
+        );
+        $this->dom->addChild(
+            $ideEvento,
+            "verProc",
+            $this->verProc,
+            true
+        );
+        $this->node->insertBefore($ideEvento, $ideEmpregador);
+
+        $ideBeneficio = $this->dom->createElement("ideBeneficio");
+        $this->dom->addChild(
+            $ideBeneficio,
+            "cpfBenef",
+            $this->std->cpfbenef,
+            true
+        );
+        $this->dom->addChild(
+            $ideBeneficio,
+            "nrBeneficio",
+            $this->std->nrbeneficio,
+            true
+        );
+        $this->node->appendChild($ideBeneficio);
+
+        $infoBenAlteracao = $this->dom->createElement("infoBenAlteracao");
+        $this->dom->addChild(
+            $infoBenAlteracao,
+            "dtAltBeneficio",
+            $this->std->dtaltbeneficio,
+            true
+        );
+        $dadosBeneficio = $this->dom->createElement("dadosBeneficio");
+        $this->dom->addChild(
+            $dadosBeneficio,
+            "tpBeneficio",
+            $this->std->tpbeneficio,
+            true
+        );
+        $this->dom->addChild(
+            $dadosBeneficio,
+            "tpPlanRP",
+            $this->std->tpplanrp,
+            true
+        );
+        $this->dom->addChild(
+            $dadosBeneficio,
+            "dsc",
+            !empty($this->std->dsc) ? $this->std->dsc : null,
+            false
+        );
+        $this->dom->addChild(
+            $dadosBeneficio,
+            "indSuspensao",
+            $this->std->indsuspensao,
+            true
+        );
+        if (!empty($this->std->infopenmorte)) {
+            $infoPenMorte = $this->dom->createElement("infoPenMorte");
+            $this->dom->addChild(
+                $infoPenMorte,
+                "tpPenMorte",
+                $this->std->infopenmorte->tppenmorte,
+                true
+            );
+            if (!empty($this->std->infopenmorte->instpenmorte)) {
+                $instPenMorte = $this->dom->createElement("instPenMorte");
+                $this->dom->addChild(
+                    $instPenMorte,
+                    "tpDepInst",
+                    $this->std->infopenmorte->instpenmorte->tpdepinst,
+                    true
+                );
+                $this->dom->addChild(
+                    $instPenMorte,
+                    "descrDepInst",
+                    $this->std->infopenmorte->instpenmorte->descrdepinst ?? null,
+                    false
+                );
+                $infoPenMorte->appendChild($instPenMorte);
+            }
+            $dadosBeneficio->appendChild($infoPenMorte);
+        }
+        if (!empty($this->std->suspensao)) {
+            $suspensao = $this->dom->createElement("suspensao");
+            $this->dom->addChild(
+                $suspensao,
+                "mtvSuspensao",
+                $this->std->suspensao->mtvsuspensao,
+                true
+            );
+            $this->dom->addChild(
+                $suspensao,
+                "dscSuspensao",
+                !empty($this->std->suspensao->dscssuspensao)
+                    ? $this->std->suspensao->dscssuspensao
+                    : null,
+                false
+            );
+            $dadosBeneficio->appendChild($suspensao);
+        }
+        $infoBenAlteracao->appendChild($dadosBeneficio);
+        $this->node->appendChild($infoBenAlteracao);
+        $this->eSocial->appendChild($this->node);
+        $this->sign();
     }
 }

--- a/src/Factories/Traits/TraitS2500.php
+++ b/src/Factories/Traits/TraitS2500.php
@@ -1267,6 +1267,611 @@ trait TraitS2500
      */
     protected function toNodeS130()
     {
-        return $this->toNodeS120();
+        $ideEmpregador = $this->node->getElementsByTagName('ideEmpregador')->item(0);
+        if (!empty($this->std->ideresp)) {
+            $ideresp = $this->dom->createElement("ideResp");
+            $this->dom->addChild(
+                $ideresp,
+                "tpInsc",
+                $this->std->ideresp->tpinsc,
+                true
+            );
+            $this->dom->addChild(
+                $ideresp,
+                "nrInsc",
+                $this->std->ideresp->nrinsc,
+                true
+            );
+            $ideEmpregador->appendChild($ideresp);
+        }
+        $ideEvento = $this->dom->createElement("ideEvento");
+        $this->dom->addChild(
+            $ideEvento,
+            "indRetif",
+            $this->std->indretif,
+            true
+        );
+        if ($this->std->indretif == 2) {
+            $this->dom->addChild(
+                $ideEvento,
+                "nrRecibo",
+                $this->std->nrrecibo,
+                true
+            );
+        }
+        $this->dom->addChild(
+            $ideEvento,
+            "tpAmb",
+            $this->tpAmb,
+            true
+        );
+        $this->dom->addChild(
+            $ideEvento,
+            "procEmi",
+            $this->procEmi,
+            true
+        );
+        $this->dom->addChild(
+            $ideEvento,
+            "verProc",
+            $this->verProc,
+            true
+        );
+        $this->node->insertBefore($ideEvento, $ideEmpregador);
+        $infoProc = $this->dom->createElement("infoProcesso");
+        $this->dom->addChild(
+            $infoProc,
+            "origem",
+            $this->std->origem,
+            true
+        );
+        $this->dom->addChild(
+            $infoProc,
+            "nrProcTrab",
+            $this->std->nrproctrab,
+            true
+        );
+        $this->dom->addChild(
+            $infoProc,
+            "obsProcTrab",
+            $this->std->obsproctrab ?? null,
+            false
+        );
+        $dados = $this->dom->createElement('dadosCompl');
+        if (!empty($this->std->infoprocjud)) {
+            $info = $this->std->infoprocjud;
+            $infojud = $this->dom->createElement('infoProcJud');
+            $this->dom->addChild(
+                $infojud,
+                "dtSent",
+                $info->dtsent,
+                true
+            );
+            $this->dom->addChild(
+                $infojud,
+                "ufVara",
+                $info->ufvara,
+                true
+            );
+            $this->dom->addChild(
+                $infojud,
+                "codMunic",
+                $info->codmunic,
+                true
+            );
+            $this->dom->addChild(
+                $infojud,
+                "idVara",
+                $info->idvara,
+                true
+            );
+            $this->dom->addChild(
+                $infojud,
+                "infoPatPrec",
+                $info->infopatprec ?? null,
+                false
+            );
+            $dados->appendChild($infojud);
+        } elseif (!empty($this->std->infoccp)) {
+            $info = $this->std->infoccp;
+            $infoccp = $this->dom->createElement('infoCCP');
+            $this->dom->addChild(
+                $infoccp,
+                "dtCCP",
+                $info->dtccp,
+                true
+            );
+            $this->dom->addChild(
+                $infoccp,
+                "tpCCP",
+                $info->tpccp,
+                true
+            );
+            $this->dom->addChild(
+                $infoccp,
+                "cnpjCCP",
+                $info->cnpjccp ?? null,
+                false
+            );
+            $dados->appendChild($infoccp);
+        }
+        $infoProc->appendChild($dados);
+        $this->node->appendChild($infoProc);
+        $idetrab = $this->dom->createElement("ideTrab");
+        $this->dom->addChild(
+            $idetrab,
+            "cpfTrab",
+            $this->std->cpftrab,
+            true
+        );
+        $this->dom->addChild(
+            $idetrab,
+            "nmTrab",
+            $this->std->nmtrab ?? null,
+            false
+        );
+        $this->dom->addChild(
+            $idetrab,
+            "dtNascto",
+            $this->std->dtnascto ?? null,
+            false
+        );
+        foreach ($this->std->infocontr as $ictr) {
+            $infoctr = $this->dom->createElement("infoContr");
+            $this->dom->addChild(
+                $infoctr,
+                "tpContr",
+                $ictr->tpcontr,
+                true
+            );
+            $this->dom->addChild(
+                $infoctr,
+                "indContr",
+                $ictr->indcontr,
+                true
+            );
+            $this->dom->addChild(
+                $infoctr,
+                "dtAdmOrig",
+                $ictr->dtadmorig ?? null,
+                false
+            );
+            $this->dom->addChild(
+                $infoctr,
+                "indReint",
+                $ictr->indreint ?? null,
+                false
+            );
+            $this->dom->addChild(
+                $infoctr,
+                "indCateg",
+                $ictr->indcateg,
+                true
+            );
+            $this->dom->addChild(
+                $infoctr,
+                "indNatAtiv",
+                $ictr->indnatativ,
+                true
+            );
+            $this->dom->addChild(
+                $infoctr,
+                "indMotDeslig",
+                $ictr->indmotdeslig,
+                true
+            );
+            $this->dom->addChild(
+                $infoctr,
+                "matricula",
+                $ictr->matricula ?? null,
+                false
+            );
+            $this->dom->addChild(
+                $infoctr,
+                "codCateg",
+                $ictr->codcateg ?? null,
+                false
+            );
+            $this->dom->addChild(
+                $infoctr,
+                "dtInicio",
+                $ictr->dtinicio ?? null,
+                false
+            );
+            if (!empty($ictr->infocompl)) {
+                $icl = $ictr->infocompl;
+                $icom = $this->dom->createElement("infoCompl");
+                $this->dom->addChild(
+                    $icom,
+                    "codCBO",
+                    $icl->codcbo ?? null,
+                    false
+                );
+                $this->dom->addChild(
+                    $icom,
+                    "natAtividade",
+                    $icl->natatividade ?? null,
+                    false
+                );
+                if (!empty($icl->remuneracao)) {
+                    foreach ($icl->remuneracao as $rem) {
+                        $remu = $this->dom->createElement("remuneracao");
+                        $this->dom->addChild(
+                            $remu,
+                            "dtRemun",
+                            $rem->dtremun,
+                            true
+                        );
+                        $this->dom->addChild(
+                            $remu,
+                            "vrSalFx",
+                            $rem->vrsalfx,
+                            true
+                        );
+                        $this->dom->addChild(
+                            $remu,
+                            "undSalFixo",
+                            $rem->undsalfixo,
+                            true
+                        );
+                        $this->dom->addChild(
+                            $remu,
+                            "dscSalVar",
+                            $rem->dscsalvar ?? null,
+                            false
+                        );
+                        $icom->appendChild($remu);
+                    }
+                }
+                if (!empty($icl->infovinc)) {
+                    $vinc = $icl->infovinc;
+                    $infoVinc = $this->dom->createElement("infoVinc");
+                    $this->dom->addChild(
+                        $infoVinc,
+                        "tpRegTrab",
+                        $vinc->tpregtrab,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $infoVinc,
+                        "tpRegPrev",
+                        $vinc->tpregprev,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $infoVinc,
+                        "dtAdm",
+                        $vinc->dtadm,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $infoVinc,
+                        "tmpParc",
+                        $vinc->tmpparc ?? null,
+                        false
+                    );
+                    if (!empty($vinc->duracao)) {
+                        $dur = $vinc->duracao;
+                        $duracao = $this->dom->createElement("duracao");
+                        $this->dom->addChild(
+                            $duracao,
+                            "tpContr",
+                            $dur->tpcontr,
+                            true
+                        );
+                        $this->dom->addChild(
+                            $duracao,
+                            "dtTerm",
+                            $dur->dtrerm ?? null,
+                            false
+                        );
+                        $this->dom->addChild(
+                            $duracao,
+                            "clauAssec",
+                            $dur->clauassec ?? null,
+                            false
+                        );
+                        $this->dom->addChild(
+                            $duracao,
+                            "objDet",
+                            $dur->objdet ?? null,
+                            false
+                        );
+                        $infoVinc->appendChild($duracao);
+                    }
+                    if (!empty($vinc->observacoes)) {
+                        foreach ($vinc->observacoes as $obs) {
+                            $observacoes = $this->dom->createElement("observacoes");
+                            $this->dom->addChild(
+                                $observacoes,
+                                "observacao",
+                                $obs->observacao,
+                                true
+                            );
+                            $infoVinc->appendChild($observacoes);
+                        }
+                    }
+                    if (!empty($vinc->sucessaovinc)) {
+                        $suss = $vinc->sucessaovinc;
+                        $sucessaoVinc = $this->dom->createElement("sucessaoVinc");
+                        $this->dom->addChild(
+                            $sucessaoVinc,
+                            "tpInsc",
+                            $suss->tpinsc,
+                            true
+                        );
+                        $this->dom->addChild(
+                            $sucessaoVinc,
+                            "nrInsc",
+                            $suss->nrinsc,
+                            true
+                        );
+                        $this->dom->addChild(
+                            $sucessaoVinc,
+                            "matricAnt",
+                            $suss->matricant ?? null,
+                            false
+                        );
+                        $this->dom->addChild(
+                            $sucessaoVinc,
+                            "dtTransf",
+                            $suss->dttransf,
+                            true
+                        );
+                        $infoVinc->appendChild($sucessaoVinc);
+                    }
+                    $des = $vinc->infodeslig;
+                    $infoDeslig = $this->dom->createElement("infoDeslig");
+                    $this->dom->addChild(
+                        $infoDeslig,
+                        "dtDeslig",
+                        $des->dtdeslig,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $infoDeslig,
+                        "mtvDeslig",
+                        $des->mtvdeslig,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $infoDeslig,
+                        "dtProjFimAPI",
+                        $des->dtprojfimapi ?? null,
+                        false
+                    );
+                    $this->dom->addChild(
+                        $infoDeslig,
+                        "pensAlim",
+                        $des->pensalim ?? null,
+                        false
+                    );
+                    $this->dom->addChild(
+                        $infoDeslig,
+                        "percAliment",
+                        $des->percaliment ?? null,
+                        false
+                    );
+                    $this->dom->addChild(
+                        $infoDeslig,
+                        "vrAlim",
+                        $des->vralim ?? null,
+                        false
+                    );
+                    $infoVinc->appendChild($infoDeslig);
+                    $icom->appendChild($infoVinc);
+                }
+                if (!empty($icl->infoterm)) {
+                    $it = $icl->infoterm;
+                    $infoTerm = $this->dom->createElement("infoTerm");
+                    $this->dom->addChild(
+                        $infoTerm,
+                        "dtTerm",
+                        $it->dtterm,
+                        true
+                    );
+                    $this->dom->addChild(
+                        $infoTerm,
+                        "mtvDesligTSV",
+                        $it->mtvdesligtsv ?? null,
+                        false
+                    );
+                    $icom->appendChild($infoTerm);
+                }
+                $infoctr->appendChild($icom);
+                if (!empty($ictr->mudcategativ)) {
+                    foreach ($ictr->mudcategativ as $mud) {
+                        $mudCategAtiv = $this->dom->createElement("mudCategAtiv");
+                        $this->dom->addChild(
+                            $mudCategAtiv,
+                            "codCateg",
+                            $mud->codcateg,
+                            true
+                        );
+                        $this->dom->addChild(
+                            $mudCategAtiv,
+                            "natAtividade",
+                            $mud->natatividade ?? null,
+                            false
+                        );
+                        $this->dom->addChild(
+                            $mudCategAtiv,
+                            "dtMudCategAtiv",
+                            $mud->dtmudcategativ,
+                            true
+                        );
+                        $infoctr->appendChild($mudCategAtiv);
+                    }
+                }
+                if (!empty($ictr->uniccontr)) {
+                    foreach ($ictr->uniccontr as $uni) {
+                        $unicContr = $this->dom->createElement("unicContr");
+                        $this->dom->addChild(
+                            $unicContr,
+                            "matUnic",
+                            $uni->matunic ?? null,
+                            false
+                        );
+                        $this->dom->addChild(
+                            $unicContr,
+                            "codCateg",
+                            $uni->codcateg ?? null,
+                            false
+                        );
+                        $this->dom->addChild(
+                            $unicContr,
+                            "dtInicio",
+                            $uni->dtinicio ?? null,
+                            false
+                        );
+                        $infoctr->appendChild($unicContr);
+                    }
+                }
+            }
+            $idestab = $ictr->ideestab;
+            $estab = $this->dom->createElement("ideEstab");
+            $this->dom->addChild(
+                $estab,
+                "tpInsc",
+                $idestab->tpinsc,
+                true
+            );
+            $this->dom->addChild(
+                $estab,
+                "nrInsc",
+                $idestab->nrinsc,
+                true
+            );
+            $vlr = $idestab->infovlr;
+            $ivlr = $this->dom->createElement("infoVlr");
+            $this->dom->addChild(
+                $ivlr,
+                "compIni",
+                $vlr->compini,
+                true
+            );
+            $this->dom->addChild(
+                $ivlr,
+                "compFim",
+                $vlr->compfim,
+                true
+            );
+            $this->dom->addChild(
+                $ivlr,
+                "indReperc",
+                $vlr->indreperc,
+                true
+            );
+            $this->dom->addChild(
+                $ivlr,
+                "indenSD",
+                $vlr->indensd,
+                true
+            );
+            $this->dom->addChild(
+                $ivlr,
+                "indenAbono",
+                $vlr->indenabono,
+                true
+            );
+            if (!empty($vlr->abono)) {
+                foreach ($vlr->abono as $ab) {
+                    $abono = $this->dom->createElement("abono");
+                    $this->dom->addChild(
+                        $abono,
+                        "anoBase",
+                        $ab->anobase,
+                        true
+                    );
+                    $ivlr->appendChild($abono);
+                }
+            }
+            if (!empty($vlr->ideperiodo)) {
+                foreach ($vlr->ideperiodo as $per) {
+                    $ideper = $this->dom->createElement("idePeriodo");
+                    $this->dom->addChild(
+                        $ideper,
+                        "perRef",
+                        $per->perref,
+                        true
+                    );
+                    if (!empty($per->basecalculo)) {
+                        $bc = $per->basecalculo;
+                        $base = $this->dom->createElement("baseCalculo");
+                        $this->dom->addChild(
+                            $base,
+                            "vrBcCpMensal",
+                            $bc->vrbccpmensal,
+                            true
+                        );
+                        $this->dom->addChild(
+                            $base,
+                            "vrBcCp13",
+                            $bc->vrbccp13,
+                            true
+                        );
+                        if (!empty($bc->infoagnocivo)) {
+                            $noc = $this->dom->createElement("infoAgNocivo");
+                            $this->dom->addChild(
+                                $noc,
+                                "grauExp",
+                                $bc->infoagnocivo->grauexp,
+                                true
+                            );
+                            $base->appendChild($noc);
+                        }
+                        $ideper->appendChild($base);
+                    }
+                    if (!empty($per->infofgts)) {
+                        $fg = $per->infofgts;
+                        $fgts = $this->dom->createElement("infoFGTS");
+                        $this->dom->addChild(
+                            $fgts,
+                            "vrBcFGTSProcTrab",
+                            $fg->vrbcfgtsproctrab,
+                            true
+                        );
+                        $this->dom->addChild(
+                            $fgts,
+                            "vrBcFGTSSefip",
+                            $fg->vrbcfgtssefip ?? null,
+                            false
+                        );
+                        $this->dom->addChild(
+                            $fgts,
+                            "vrBcFGTSDecAnt",
+                            $fg->vrbcfgtsdecant ?? null,
+                            false
+                        );
+                        $ideper->appendChild($fgts);
+                    }
+                    if (!empty($per->basemudcateg)) {
+                        $bm = $per->basemudcateg;
+                        $mudab = $this->dom->createElement("baseMudCateg");
+                        $this->dom->addChild(
+                            $mudab,
+                            "codCateg",
+                            $bm->codcateg,
+                            true
+                        );
+                        $this->dom->addChild(
+                            $mudab,
+                            "vrBcCPrev",
+                            $bm->vrbccprev,
+                            true
+                        );
+                        $ideper->appendChild($mudab);
+                    }
+                    $ivlr->appendChild($ideper);
+                }
+            }
+            $estab->appendChild($ivlr);
+            $infoctr->appendChild($estab);
+
+            $idetrab->appendChild($infoctr);
+        }
+        $this->node->appendChild($idetrab);
+        $this->eSocial->appendChild($this->node);
+        $this->sign();
     }
 }


### PR DESCRIPTION
## Suporte à NT S-1.3 nº 06/2026 (2ª rodada) — layout `v_S_01_03_00`

Implementação das alterações introduzidas pela **Nota Técnica S-1.3 nº 06/2026** no layout S.1.3.0 do eSocial. Atualiza XSDs, Traits PHP, Fakers, jsonSchemes e documentação.

---

### Mudança transversal — CNPJ alfanumérico

O tipo `TS_cnpj` e os tipos derivados (`TS_nrInsc_*`) passam a aceitar letras maiúsculas nos 12 primeiros caracteres: `[A-Z0-9]{12}\d{2}`.

Impacto: **24 XSDs** e **25 jsonSchemes** atualizados com o novo pattern. Corrigido também typo de regex em `evtTabLotacao.schema` (`}}` → `}`).

---

### Novos tipos em `tipos.xsd`

| Tipo | Descrição |
|---|---|
| `TS_notAFT` | Notificação FGTS Digital — 9 chars alfanuméricos |
| `TS_descFolha` | Grupo eConsignado em rubricas de folha |
| `TS_tpDepInst` | Tipo de dependente do instituidor de pensão por morte |
| `TS_descrDepInst` | Descrição complementar do tipo de dependente |

---

### Eventos alterados

#### S-1200 — Remuneração do Trabalhador
- Novo campo opcional **`notAFT`** em `dmDev`, após `indRRA`.
  Identifica a notificação FGTS Digital que originou a confissão de débito na competência.

#### S-2299 — Desligamento
- Novo campo opcional **`notAFT`** em `verbasResc/dmDev`, após `indRRA`.
  Se informado, `infoPerAnt` não pode ser preenchido.

#### S-2399 — TSV Término
- Implementada **`toNodeS130()`** completa (anteriormente delegava para `toNodeS110()`).
- Inclui **`notAFT`** em `verbasResc/dmDev`, além de suporte explícito a `indRRA` e `infoRRA`.

#### S-2410 — Cadastro de Benefício — Início (Entes Públicos)
- Novos campos opcionais **`tpDepInst`** e **`descrDepInst`** dentro do grupo `instPenMorte` em `infoPenMorte`.
- Novo grupo **`infoHomolog`** (`sitHomolog`, `dtHomolog?`) em `dadosBeneficio` para indicação de homologação TCU.

#### S-2416 — Cadastro de Benefício — Alteração (Entes Públicos)
- Implementada **`toNodeS130()`** completa (anteriormente delegava para `toNodeS100()`).
- Novo grupo opcional **`instPenMorte`** com `tpDepInst` (obrigatório no grupo) e `descrDepInst?`.
  > Diferença do S-2410: S-2416 **não** possui `cpfInst`/`dtInst` em `instPenMorte`.

#### S-2500 — Processo Trabalhista
- Implementada **`toNodeS130()`** completa (anteriormente delegava para `toNodeS120()`).
- Novo campo **`infoPatPrec`** (valor monetário) em `infoProcJud`, obrigatório quando `origem = 3` (Justiça Comum).
- Enum `origem` recebe valor `3` = Justiça Comum.

---

### XSDs atualizados sem implementação PHP

Eventos de retorno (S-5xxx) e demais eventos sem alterações nas Traits:
S-1010, S-1202, S-1210, S-2190, S-2200, S-2300, S-2415, S-2418, S-2420, S-2600, S-5001, S-5003, S-5012, S-5013 e consolidações.

---

### Referência

- [Nota Técnica S-1.3 nº 06/2026 — eSocial](https://www.gov.br/esocial/pt-br/centrais-de-conteudo/agenda/2026-07-01-entrada-em-producao-dos-esquemas-xsd-esocial-leiautes-v-s-1-3-ate-nt-06-2026-cnpj-alfanumerico)
